### PR TITLE
refactor: cli hardening

### DIFF
--- a/.xcli.example.yaml
+++ b/.xcli.example.yaml
@@ -4,9 +4,9 @@
 # Repository paths (auto-discovered or manually specified)
 repos:
   cbt: ../cbt
-  xatu_cbt: ../xatu-cbt
-  cbt_api: ../cbt-api
-  lab_backend: ../lab-backend
+  xatuCbt: ../xatu-cbt
+  cbtApi: ../cbt-api
+  labBackend: ../lab-backend
   lab: ../lab
 
 # Operating mode: "local" or "hybrid"
@@ -19,14 +19,14 @@ mode: local
 networks:
   - name: mainnet
     enabled: true
-    port_offset: 0  # CBT: 8081, cbt-api: 8091
+    portOffset: 0  # CBT: 8081, cbt-api: 8091
   - name: sepolia
     enabled: true
-    port_offset: 1  # CBT: 8082, cbt-api: 8092
+    portOffset: 1  # CBT: 8082, cbt-api: 8092
   # Add more networks as needed:
   # - name: holesky
   #   enabled: false
-  #   port_offset: 2
+  #   portOffset: 2
 
 # Infrastructure configuration
 infrastructure:
@@ -52,10 +52,10 @@ infrastructure:
 #       #   HTTP:  http://username:password@host:8123
 #       #   HTTPS: https://username:password@host:8443
 #       #   Native: clickhouse://username:password@host:9000
-#       external_url: "https://readonly:supersecret@prod-xatu.example.com:8443"
-#       external_database: "default"
-#       external_username: "readonly"
-#       external_password: "supersecret"
+#       externalUrl: "https://readonly:supersecret@prod-xatu.example.com:8443"
+#       externalDatabase: "default"
+#       externalUsername: "readonly"
+#       externalPassword: "supersecret"
 #     cbt:
 #       mode: local  # CBT cluster always runs locally
 
@@ -72,12 +72,12 @@ infrastructure:
 
 # Port configuration
 ports:
-  lab_backend: 8080
-  lab_frontend: 5173
-  cbt_base: 8081      # Base port for CBT engines (+ network offset)
-  cbt_api_base: 8091  # Base port for cbt-api services (+ network offset)
+  labBackend: 8080
+  labFrontend: 5173
+  cbtBase: 8081      # Base port for CBT engines (+ network offset)
+  cbtApiBase: 8091  # Base port for cbt-api services (+ network offset)
 
 # Development features
 dev:
-  lab_rebuild_on_change: false  # Auto-rebuild lab frontend on changes
-  hot_reload: true              # Enable hot reload for services that support it
+  labRebuildOnChange: false  # Auto-rebuild lab frontend on changes
+  hotReload: true              # Enable hot reload for services that support it

--- a/README.md
+++ b/README.md
@@ -57,10 +57,18 @@ xcli lab build               # Build all repositories
 ### Service Management
 
 ```bash
+# View logs
 xcli lab logs                    # View all logs
 xcli lab logs lab-backend        # View specific service logs
 xcli lab logs -f lab-backend     # Follow logs
 
+# Start/stop individual services
+xcli lab start lab-backend       # Start a specific service
+xcli lab stop lab-frontend       # Stop a specific service
+xcli lab start cbt-mainnet       # Start CBT engine for mainnet
+xcli lab stop cbt-api-sepolia    # Stop cbt-api for sepolia
+
+# Restart services
 xcli lab restart lab-backend     # Restart a specific service
 xcli lab restart cbt-api-mainnet # Restart mainnet cbt-api
 ```
@@ -88,6 +96,22 @@ xcli lab build -f                # Force rebuild
 
 ## Common Workflows
 
+### Start/Stop Individual Services
+
+Manage services independently without affecting the whole stack:
+
+```bash
+# Stop a service temporarily
+xcli lab stop lab-frontend
+
+# Start it again later
+xcli lab start lab-frontend
+
+# Useful for debugging - stop resource-intensive services
+xcli lab stop cbt-mainnet
+xcli lab stop cbt-api-mainnet
+```
+
 ### Restart a Single Service
 
 After making code changes to a specific service:
@@ -97,7 +121,11 @@ After making code changes to a specific service:
 xcli lab restart lab-backend
 
 # Example: After editing CBT transformation
-xcli lab restart cbt-engine-mainnet
+xcli lab restart cbt-mainnet
+
+# Note: Restart only works if service is already running
+# If service crashed, use 'start' instead
+xcli lab start cbt-mainnet
 ```
 
 ### Regenerate Protos
@@ -127,13 +155,13 @@ Enable or disable networks in `.xcli.yaml`:
 networks:
   - name: mainnet
     enabled: true
-    port_offset: 0
+    portOffset: 0
   - name: sepolia
     enabled: true
-    port_offset: 1
+    portOffset: 1
   - name: holesky
     enabled: true
-    port_offset: 2  # CBT: 8083, cbt-api: 8093
+    portOffset: 2  # CBT: 8083, cbt-api: 8093
 ```
 
 Then restart:
@@ -157,7 +185,8 @@ xcli lab mode hybrid
 #   clickhouse:
 #     xatu:
 #       mode: external
-#       external_url: "https://user:pass@host:8443"
+#       externalUrl: "https://user:pass@host:8443"
+#       externalDatabase: "default"
 
 # Restart services
 xcli lab down && xcli lab up
@@ -171,7 +200,7 @@ xcli lab logs
 
 # Specific service
 xcli lab logs lab-backend
-xcli lab logs cbt-engine-mainnet
+xcli lab logs cbt-mainnet
 xcli lab logs cbt-api-sepolia
 
 # Follow logs (live tail)
@@ -203,9 +232,9 @@ The `.xcli.yaml` file is created by `xcli lab init` and can be customized:
 lab:
   repos:
     cbt: ../cbt
-    xatu_cbt: ../xatu-cbt
-    cbt_api: ../cbt-api
-    lab_backend: ../lab-backend
+    xatuCbt: ../xatu-cbt
+    cbtApi: ../cbt-api
+    labBackend: ../lab-backend
     lab: ../lab
 
   mode: local  # or "hybrid"
@@ -213,16 +242,16 @@ lab:
   networks:
     - name: mainnet
       enabled: true
-      port_offset: 0
+      portOffset: 0
     - name: sepolia
       enabled: true
-      port_offset: 1
+      portOffset: 1
 
   ports:
-    lab_backend: 8080
-    lab_frontend: 5173
-    cbt_base: 8081      # Base port for CBT engines
-    cbt_api_base: 8091  # Base port for cbt-api services
+    labBackend: 8080
+    labFrontend: 5173
+    cbtBase: 8081      # Base port for CBT engines
+    cbtApiBase: 8091  # Base port for cbt-api services
 
   infrastructure:
     clickhouse:
@@ -237,19 +266,3 @@ lab:
 ```
 
 See [`.xcli.example.yaml`](.xcli.example.yaml) for full options.
-
-## Troubleshooting
-
-### Services won't start
-
-```bash
-# Check logs
-xcli lab logs
-
-# Validate config
-xcli lab config validate
-
-# Clean restart
-xcli lab down
-xcli lab up
-```

--- a/pkg/commands/lab.go
+++ b/pkg/commands/lab.go
@@ -20,6 +20,8 @@ func NewLabCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
 	cmd.AddCommand(NewLabBuildCommand(log, configPath))
 	cmd.AddCommand(NewLabPsCommand(log, configPath))
 	cmd.AddCommand(NewLabLogsCommand(log, configPath))
+	cmd.AddCommand(NewLabStartCommand(log, configPath))
+	cmd.AddCommand(NewLabStopCommand(log, configPath))
 	cmd.AddCommand(NewLabRestartCommand(log, configPath))
 	cmd.AddCommand(NewLabModeCommand(log, configPath))
 	cmd.AddCommand(NewLabConfigCommand(log, configPath))

--- a/pkg/commands/lab_build.go
+++ b/pkg/commands/lab_build.go
@@ -37,7 +37,8 @@ For a complete build including proto generation, use 'xcli lab up --rebuild'.`,
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			if err := cfg.Lab.Validate(); err != nil {
+			// Only validate repo paths for build command - infrastructure config not needed
+			if err := cfg.Lab.ValidateRepos(); err != nil {
 				return fmt.Errorf("invalid lab configuration: %w", err)
 			}
 

--- a/pkg/commands/lab_start.go
+++ b/pkg/commands/lab_start.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/ethpandaops/xcli/pkg/orchestrator"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewLabStartCommand creates the lab start command.
+func NewLabStartCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "start <service>",
+		Short: "Start a specific lab service",
+		Long: `Start a specific lab service.
+
+Available services:
+  - lab-backend
+  - lab-frontend
+  - cbt-<network>        (e.g., cbt-mainnet, cbt-sepolia)
+  - cbt-api-<network>    (e.g., cbt-api-mainnet, cbt-api-sepolia)
+
+Example:
+  xcli lab start lab-backend
+  xcli lab start cbt-mainnet`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			if cfg.Lab == nil {
+				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+			}
+
+			orch := orchestrator.NewOrchestrator(log, cfg.Lab)
+
+			if err := orch.StartService(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("failed to start service: %w", err)
+			}
+
+			fmt.Printf("\n✓ Service %s started successfully\n", args[0])
+
+			return nil
+		},
+	}
+}

--- a/pkg/commands/lab_stop.go
+++ b/pkg/commands/lab_stop.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/ethpandaops/xcli/pkg/orchestrator"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewLabStopCommand creates the lab stop command.
+func NewLabStopCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop <service>",
+		Short: "Stop a specific lab service",
+		Long: `Stop a specific lab service.
+
+Available services:
+  - lab-backend
+  - lab-frontend
+  - cbt-<network>        (e.g., cbt-mainnet, cbt-sepolia)
+  - cbt-api-<network>    (e.g., cbt-api-mainnet, cbt-api-sepolia)
+
+Example:
+  xcli lab stop lab-backend
+  xcli lab stop cbt-mainnet`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			if cfg.Lab == nil {
+				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+			}
+
+			orch := orchestrator.NewOrchestrator(log, cfg.Lab)
+
+			if err := orch.StopService(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("failed to stop service: %w", err)
+			}
+
+			fmt.Printf("\n✓ Service %s stopped successfully\n", args[0])
+
+			return nil
+		},
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,65 @@
+package constants
+
+// Stack modes.
+const (
+	ModeLocal  = "local"
+	ModeHybrid = "hybrid"
+)
+
+// Infrastructure modes.
+const (
+	InfraModeLocal    = "local"
+	InfraModeExternal = "external"
+)
+
+// Service names and prefixes.
+const (
+	ServiceLabBackend   = "lab-backend"
+	ServiceLabFrontend  = "lab-frontend"
+	ServicePrefixCBT    = "cbt-"
+	ServicePrefixCBTAPI = "cbt-api-"
+)
+
+// Binary names.
+const (
+	BinaryCBT        = "cbt"
+	BinaryCBTAPI     = "server"
+	BinaryLabBackend = "lab-backend"
+)
+
+// Directory names.
+const (
+	DirBin           = "bin"
+	DirConfigs       = "configs"
+	DirCustomConfigs = "custom-configs"
+	DirLogs          = "logs"
+	DirPIDs          = "pids"
+)
+
+// Config file templates.
+const (
+	ConfigFileCBT        = "cbt-%s.yaml"
+	ConfigFileCBTAPI     = "cbt-api-%s.yaml"
+	ConfigFileLabBackend = "lab-backend.yaml"
+)
+
+// PID file template.
+const (
+	PIDFileTemplate = "%s.pid"
+)
+
+// Log file template.
+const (
+	LogFileTemplate = "%s.log"
+)
+
+// Service name helpers.
+// ServiceName returns the full service name for a network-specific service.
+func ServiceNameCBT(network string) string {
+	return ServicePrefixCBT + network
+}
+
+// ServiceNameCBTAPI returns the full service name for a cbt-api instance.
+func ServiceNameCBTAPI(network string) string {
+	return ServicePrefixCBTAPI + network
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -3,14 +3,18 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethpandaops/xcli/pkg/builder"
 	"github.com/ethpandaops/xcli/pkg/config"
 	"github.com/ethpandaops/xcli/pkg/configgen"
+	"github.com/ethpandaops/xcli/pkg/constants"
 	"github.com/ethpandaops/xcli/pkg/infrastructure"
+	"github.com/ethpandaops/xcli/pkg/portutil"
 	"github.com/ethpandaops/xcli/pkg/process"
 	"github.com/sirupsen/logrus"
 )
@@ -102,6 +106,16 @@ func (o *Orchestrator) Up(ctx context.Context, skipBuild bool, forceBuild bool) 
 		}
 	}
 
+	// Check for port conflicts before starting services
+	o.log.Info("checking for port conflicts")
+
+	if conflicts := o.checkPortConflicts(); len(conflicts) > 0 {
+		fmt.Println("\n⚠ Port conflicts detected!")
+		fmt.Print(portutil.FormatConflicts(conflicts))
+
+		return fmt.Errorf("port conflicts prevent starting services")
+	}
+
 	// Start services
 	if err := o.startServices(ctx); err != nil {
 		return fmt.Errorf("failed to start services: %w", err)
@@ -132,6 +146,21 @@ func (o *Orchestrator) Down(ctx context.Context) error {
 		o.log.WithError(err).Warn("failed to stop services")
 	}
 
+	// Check for and clean up orphaned processes
+	o.log.Info("checking for orphaned processes")
+
+	orphanedCount := o.cleanupOrphanedProcesses()
+	if orphanedCount > 0 {
+		o.log.WithField("count", orphanedCount).Info("cleaned up orphaned processes")
+	}
+
+	// Clean log files
+	o.log.Info("cleaning log files")
+
+	if err := o.proc.CleanLogs(); err != nil {
+		o.log.WithError(err).Warn("failed to clean logs")
+	}
+
 	// Reset infrastructure (stops containers and removes volumes)
 	o.log.Info("resetting infrastructure")
 
@@ -141,15 +170,82 @@ func (o *Orchestrator) Down(ctx context.Context) error {
 
 	o.log.Info("teardown complete")
 	fmt.Println("\n✓ Stack torn down successfully")
-	fmt.Println("\nAll services stopped and volumes removed.")
-	fmt.Println("Run 'xcli up' to start fresh.")
+	fmt.Println("\nAll services stopped, logs cleaned, and volumes removed.")
+	fmt.Println("Run 'xcli lab up' to start fresh.")
+
+	return nil
+}
+
+// StopServices stops all running services without tearing down infrastructure.
+func (o *Orchestrator) StopServices() error {
+	o.log.Info("stopping all services")
+
+	if err := o.proc.StopAll(); err != nil {
+		return fmt.Errorf("failed to stop services: %w", err)
+	}
 
 	return nil
 }
 
 // Restart restarts a specific service.
 func (o *Orchestrator) Restart(ctx context.Context, service string) error {
-	return o.proc.Restart(ctx, service)
+	// Stop the service
+	if err := o.StopService(ctx, service); err != nil {
+		return fmt.Errorf("failed to stop service: %w", err)
+	}
+
+	o.log.WithField("service", service).Info("service stopped, starting again")
+
+	// Start it again
+	return o.StartService(ctx, service)
+}
+
+// StartService starts a specific service by name.
+func (o *Orchestrator) StartService(ctx context.Context, service string) error {
+	// Use background context for long-running processes
+	processCtx := context.Background()
+
+	// Parse service name to determine type and network
+	switch {
+	case service == constants.ServiceLabBackend:
+		return o.startLabBackend(processCtx)
+	case service == constants.ServiceLabFrontend:
+		return o.startLabFrontend(processCtx)
+	case strings.HasPrefix(service, constants.ServicePrefixCBTAPI):
+		network := strings.TrimPrefix(service, constants.ServicePrefixCBTAPI)
+		// Validate network is enabled
+		if !o.isNetworkEnabled(network) {
+			return fmt.Errorf("network %s is not enabled in config", network)
+		}
+
+		return o.startCBTAPI(processCtx, network)
+	case strings.HasPrefix(service, constants.ServicePrefixCBT):
+		network := strings.TrimPrefix(service, constants.ServicePrefixCBT)
+		// Validate network is enabled
+		if !o.isNetworkEnabled(network) {
+			return fmt.Errorf("network %s is not enabled in config", network)
+		}
+
+		return o.startCBTEngine(processCtx, network)
+	default:
+		return fmt.Errorf("unknown service: %s", service)
+	}
+}
+
+// StopService stops a specific service by name.
+func (o *Orchestrator) StopService(ctx context.Context, service string) error {
+	return o.proc.Stop(service)
+}
+
+// isNetworkEnabled checks if a network is enabled in the configuration.
+func (o *Orchestrator) isNetworkEnabled(network string) bool {
+	for _, net := range o.cfg.EnabledNetworks() {
+		if net.Name == network {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Logs shows logs for a service.
@@ -184,7 +280,7 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 	infraStatus := o.infra.Status()
 
 	// In hybrid mode, handle Xatu ClickHouse differently
-	isHybrid := o.cfg.Mode == "hybrid"
+	isHybrid := o.cfg.Mode == constants.ModeHybrid
 
 	for name, running := range infraStatus {
 		// Skip showing Xatu ClickHouse status in hybrid mode (it's external)
@@ -202,9 +298,10 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 
 	// In hybrid mode, show external Xatu connection info
 	if isHybrid {
+		externalInfo := o.sanitizeURL(o.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL)
 		fmt.Printf("  %-20s ↗ external (%s)\n",
 			"ClickHouse Xatu",
-			o.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL,
+			externalInfo,
 		)
 	}
 
@@ -220,7 +317,105 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 		}
 	}
 
+	// Check for orphaned processes
+	conflicts := o.checkPortConflicts()
+	if len(conflicts) > 0 && len(processes) == 0 {
+		// Only show orphan warning if no managed processes are running
+		fmt.Println("\n⚠ Warning: Orphaned processes detected on lab ports")
+		fmt.Println("These processes may be from a previous xcli session:")
+
+		for _, c := range conflicts {
+			if c.PID > 0 {
+				processInfo := fmt.Sprintf("PID %d", c.PID)
+
+				if c.Process != "" {
+					processInfo = fmt.Sprintf("%s (%s)", processInfo, c.Process)
+				}
+
+				fmt.Printf("  Port %d: %s\n", c.Port, processInfo)
+			}
+		}
+
+		fmt.Println("\nRun 'xcli lab down' to clean up orphaned processes")
+	}
+
 	return nil
+}
+
+// checkPortConflicts checks if any ports needed by services are already in use.
+func (o *Orchestrator) checkPortConflicts() []portutil.PortConflict {
+	portsToCheck := make([]int, 0)
+	enabledNetworks := o.cfg.EnabledNetworks()
+
+	// Lab backend and frontend ports
+	portsToCheck = append(portsToCheck, o.cfg.Ports.LabBackend)
+	portsToCheck = append(portsToCheck, o.cfg.Ports.LabFrontend)
+
+	// CBT and CBT API ports for each enabled network
+	for i, network := range enabledNetworks {
+		// CBT API service port
+		portsToCheck = append(portsToCheck, o.cfg.GetCBTAPIPort(network.Name))
+
+		// CBT metrics port (9100 + network index)
+		portsToCheck = append(portsToCheck, 9100+i)
+
+		// CBT API metrics port (9200 + network index)
+		portsToCheck = append(portsToCheck, 9200+i)
+	}
+
+	return portutil.CheckPorts(portsToCheck)
+}
+
+// cleanupOrphanedProcesses finds and kills orphaned lab processes on expected ports.
+// Returns the number of processes killed.
+func (o *Orchestrator) cleanupOrphanedProcesses() int {
+	conflicts := o.checkPortConflicts()
+	if len(conflicts) == 0 {
+		return 0
+	}
+
+	killedCount := 0
+
+	for _, conflict := range conflicts {
+		if conflict.PID > 0 {
+			o.log.WithFields(logrus.Fields{
+				"pid":     conflict.PID,
+				"port":    conflict.Port,
+				"process": conflict.Process,
+			}).Info("killing orphaned process")
+
+			if err := portutil.KillProcess(conflict.PID); err != nil {
+				o.log.WithError(err).Warnf("failed to kill process %d", conflict.PID)
+			} else {
+				killedCount++
+			}
+		}
+	}
+
+	return killedCount
+}
+
+// sanitizeURL removes credentials from a URL for display purposes.
+func (o *Orchestrator) sanitizeURL(rawURL string) string {
+	if rawURL == "" {
+		return "not configured"
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		// If parsing fails, just show the host part or return as-is
+		return rawURL
+	}
+
+	// Remove password if present
+	if parsedURL.User != nil {
+		username := parsedURL.User.Username()
+		if username != "" {
+			parsedURL.User = url.User(username) // Keep username, remove password
+		}
+	}
+
+	return parsedURL.String()
 }
 
 // hasCustomConfig checks if a custom config exists in the custom-configs directory.
@@ -261,7 +456,7 @@ func (o *Orchestrator) generateConfigs() error {
 	// Generate configs for each network
 	for _, network := range o.cfg.EnabledNetworks() {
 		// CBT config
-		cbtFilename := fmt.Sprintf("cbt-%s.yaml", network.Name)
+		cbtFilename := fmt.Sprintf(constants.ConfigFileCBT, network.Name)
 		cbtPath := filepath.Join(configsDir, cbtFilename)
 
 		if hasCustom, customPath := o.hasCustomConfig(cbtFilename); hasCustom {
@@ -283,7 +478,7 @@ func (o *Orchestrator) generateConfigs() error {
 		}
 
 		// cbt-api config
-		apiFilename := fmt.Sprintf("cbt-api-%s.yaml", network.Name)
+		apiFilename := fmt.Sprintf(constants.ConfigFileCBTAPI, network.Name)
 		apiPath := filepath.Join(configsDir, apiFilename)
 
 		if hasCustom, customPath := o.hasCustomConfig(apiFilename); hasCustom {
@@ -306,7 +501,7 @@ func (o *Orchestrator) generateConfigs() error {
 	}
 
 	// lab-backend config
-	backendFilename := "lab-backend.yaml"
+	backendFilename := constants.ConfigFileLabBackend
 	backendPath := filepath.Join(configsDir, backendFilename)
 
 	if hasCustom, customPath := o.hasCustomConfig(backendFilename); hasCustom {
@@ -369,12 +564,12 @@ func (o *Orchestrator) startServices(ctx context.Context) error {
 
 // startCBTEngine starts a CBT engine for a network.
 func (o *Orchestrator) startCBTEngine(ctx context.Context, network string) error {
-	cbtBinary := filepath.Join(o.cfg.Repos.CBT, "bin", "cbt")
+	cbtBinary := filepath.Join(o.cfg.Repos.CBT, constants.DirBin, constants.BinaryCBT)
 	if _, err := os.Stat(cbtBinary); os.IsNotExist(err) {
 		return fmt.Errorf("cbt binary not found at %s - please run 'make build' in cbt repo", cbtBinary)
 	}
 
-	configPath, err := filepath.Abs(filepath.Join(o.stateDir, "configs", fmt.Sprintf("cbt-%s.yaml", network)))
+	configPath, err := filepath.Abs(filepath.Join(o.stateDir, constants.DirConfigs, fmt.Sprintf(constants.ConfigFileCBT, network)))
 	if err != nil {
 		return err
 	}
@@ -384,17 +579,17 @@ func (o *Orchestrator) startCBTEngine(ctx context.Context, network string) error
 
 	cmd.Env = append(os.Environ(), fmt.Sprintf("NETWORK=%s", network))
 
-	return o.proc.Start(ctx, fmt.Sprintf("cbt-%s", network), cmd)
+	return o.proc.Start(ctx, constants.ServiceNameCBT(network), cmd)
 }
 
 // startCBTAPI starts cbt-api for a network.
 func (o *Orchestrator) startCBTAPI(ctx context.Context, network string) error {
-	apiBinary := filepath.Join(o.cfg.Repos.CBTAPI, "bin", "server")
+	apiBinary := filepath.Join(o.cfg.Repos.CBTAPI, constants.DirBin, constants.BinaryCBTAPI)
 	if _, err := os.Stat(apiBinary); os.IsNotExist(err) {
 		return fmt.Errorf("cbt-api binary not found at %s - please run 'make build' in cbt-api repo", apiBinary)
 	}
 
-	configPath, err := filepath.Abs(filepath.Join(o.stateDir, "configs", fmt.Sprintf("cbt-api-%s.yaml", network)))
+	configPath, err := filepath.Abs(filepath.Join(o.stateDir, constants.DirConfigs, fmt.Sprintf(constants.ConfigFileCBTAPI, network)))
 	if err != nil {
 		return err
 	}
@@ -402,17 +597,17 @@ func (o *Orchestrator) startCBTAPI(ctx context.Context, network string) error {
 	cmd := exec.CommandContext(ctx, apiBinary, "--config", configPath)
 	cmd.Dir = o.cfg.Repos.CBTAPI
 
-	return o.proc.Start(ctx, fmt.Sprintf("cbt-api-%s", network), cmd)
+	return o.proc.Start(ctx, constants.ServiceNameCBTAPI(network), cmd)
 }
 
 // startLabBackend starts lab-backend.
 func (o *Orchestrator) startLabBackend(ctx context.Context) error {
-	backendBinary := filepath.Join(o.cfg.Repos.LabBackend, "bin", "lab-backend")
+	backendBinary := filepath.Join(o.cfg.Repos.LabBackend, constants.DirBin, constants.BinaryLabBackend)
 	if _, err := os.Stat(backendBinary); os.IsNotExist(err) {
 		return fmt.Errorf("lab-backend binary not found at %s - please run 'make build' in lab-backend repo", backendBinary)
 	}
 
-	configPath, err := filepath.Abs(filepath.Join(o.stateDir, "configs", "lab-backend.yaml"))
+	configPath, err := filepath.Abs(filepath.Join(o.stateDir, constants.DirConfigs, constants.ConfigFileLabBackend))
 	if err != nil {
 		return err
 	}
@@ -420,7 +615,7 @@ func (o *Orchestrator) startLabBackend(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, backendBinary, "--config", configPath)
 	cmd.Dir = o.cfg.Repos.LabBackend
 
-	return o.proc.Start(ctx, "lab-backend", cmd)
+	return o.proc.Start(ctx, constants.ServiceLabBackend, cmd)
 }
 
 // startLabFrontend starts the lab frontend dev server.
@@ -451,5 +646,5 @@ func (o *Orchestrator) startLabFrontend(ctx context.Context) error {
 		fmt.Sprintf("VITE_BACKEND_URL=http://localhost:%d", o.cfg.Ports.LabBackend),
 	)
 
-	return o.proc.Start(ctx, "lab-frontend", cmd)
+	return o.proc.Start(ctx, constants.ServiceLabFrontend, cmd)
 }

--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -1,0 +1,139 @@
+package portutil
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// PortConflict represents a port that's already in use.
+type PortConflict struct {
+	Port    int
+	Service string
+	PID     int
+	Process string
+}
+
+// CheckPort checks if a port is available.
+// Returns nil if available, or a PortConflict if the port is in use.
+func CheckPort(port int) *PortConflict {
+	// Try to listen on the port
+	addr := fmt.Sprintf(":%d", port)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		// Port is in use, try to find what's using it
+		return findPortOwner(port)
+	}
+
+	// Port is available
+	listener.Close()
+
+	return nil
+}
+
+// CheckPorts checks multiple ports and returns all conflicts.
+func CheckPorts(ports []int) []PortConflict {
+	var conflicts []PortConflict
+
+	for _, port := range ports {
+		if conflict := CheckPort(port); conflict != nil {
+			conflicts = append(conflicts, *conflict)
+		}
+	}
+
+	return conflicts
+}
+
+// findPortOwner tries to find the process using a port.
+func findPortOwner(port int) *PortConflict {
+	conflict := &PortConflict{
+		Port: port,
+	}
+
+	// Try lsof (macOS/Linux)
+	//nolint:gosec // Port number is validated to be an integer
+	cmd := exec.Command("/usr/sbin/lsof", "-i", fmt.Sprintf(":%d", port), "-sTCP:LISTEN", "-t")
+
+	output, err := cmd.Output()
+	if err == nil && len(output) > 0 {
+		pidStr := strings.TrimSpace(string(output))
+		if pid, err := strconv.Atoi(pidStr); err == nil {
+			conflict.PID = pid
+			// Get process name
+			psCmd := exec.Command("ps", "-p", pidStr, "-o", "comm=")
+			if psOutput, err := psCmd.Output(); err == nil {
+				conflict.Process = strings.TrimSpace(string(psOutput))
+			}
+		}
+	}
+
+	return conflict
+}
+
+// FormatConflicts formats port conflicts for display.
+func FormatConflicts(conflicts []PortConflict) string {
+	if len(conflicts) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Port conflicts detected:\n")
+
+	for _, c := range conflicts {
+		sb.WriteString(fmt.Sprintf("  Port %d: in use", c.Port))
+
+		if c.PID > 0 {
+			sb.WriteString(fmt.Sprintf(" by PID %d", c.PID))
+
+			if c.Process != "" {
+				sb.WriteString(fmt.Sprintf(" (%s)", c.Process))
+			}
+		}
+
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\nTo fix this:\n")
+	sb.WriteString("  1. Run 'xcli lab down' to clean up\n")
+
+	if len(conflicts) > 0 && conflicts[0].PID > 0 {
+		sb.WriteString("  2. Or manually kill processes: ")
+
+		pids := make([]string, 0, len(conflicts))
+		for _, c := range conflicts {
+			if c.PID > 0 {
+				pids = append(pids, strconv.Itoa(c.PID))
+			}
+		}
+
+		if len(pids) > 0 {
+			sb.WriteString(fmt.Sprintf("kill %s\n", strings.Join(pids, " ")))
+		}
+	}
+
+	return sb.String()
+}
+
+// KillProcess attempts to kill a process by PID.
+// Sends SIGTERM first, then SIGKILL if needed.
+func KillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid PID: %d", pid)
+	}
+
+	// Use kill command for cross-platform compatibility
+	//nolint:gosec // PID is validated to be a positive integer
+	cmd := exec.Command("kill", strconv.Itoa(pid))
+	if err := cmd.Run(); err != nil {
+		// Try force kill if graceful kill failed
+		//nolint:gosec // PID is validated to be a positive integer
+		forceCmd := exec.Command("kill", "-9", strconv.Itoa(pid))
+
+		return forceCmd.Run()
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Standardize all YAML keys to camelCase for consistency with industry conventions
- Introduce constants package to centralize magic strings and improve maintainability
- Add StartService/StopService methods for per-service lifecycle management
- Implement port conflict detection and orphaned-process cleanup on up/down
- Enhance signal handling during lab up to gracefully terminate services
- Validate external ClickHouse credentials when switching to hybrid mode
- Truncate log files on start to prevent unbounded growth
- Update documentation and examples to match new key names