### PR TITLE
feat: add automatic cloning of missing lab repositories

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,13 +53,13 @@ const (
 
 // GitHub repository URLs.
 const (
-	GitHubOrg          = "ethpandaops"
-	RepoCBT            = "cbt"
-	RepoXatuCBT        = "xatu-cbt"
-	RepoCBTAPI         = "cbt-api"
-	RepoLabBackend     = "lab-backend"
-	RepoLab            = "lab"
-	GitHubURLTemplate  = "https://github.com/%s/%s.git"
+	GitHubOrg         = "ethpandaops"
+	RepoCBT           = "cbt"
+	RepoXatuCBT       = "xatu-cbt"
+	RepoCBTAPI        = "cbt-api"
+	RepoLabBackend    = "lab-backend"
+	RepoLab           = "lab"
+	GitHubURLTemplate = "https://github.com/%s/%s.git"
 )
 
 // GetGitHubURL returns the GitHub clone URL for a repository.

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -66,9 +66,11 @@ func (d *Discovery) DiscoverRepos() (*config.LabReposConfig, error) {
 				if info.branch != "" {
 					branchInfo = fmt.Sprintf(" (branch: %s)", info.branch)
 				}
+
 				fmt.Printf("Would you like to clone it from GitHub?%s (Y/n): ", branchInfo)
 
 				var response string
+
 				_, _ = fmt.Scanln(&response)
 
 				// Default to yes if empty or "y"/"Y"


### PR DESCRIPTION
Introduce GitHub repository constants and a GetGitHubURL helper to centralize repo URLs. Extend DiscoverRepos to detect missing repos, prompt the user, and clone them on demand. Repos can optionally specify a branch (e.g., lab uses release/frontend).

part of https://github.com/ethpandaops/xcli/issues/13