### PR TITLE
feat(lab): add regenerate subcommand to recreate service configs

### DIFF
--- a/pkg/commands/lab_config.go
+++ b/pkg/commands/lab_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/ethpandaops/xcli/pkg/orchestrator"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -75,6 +76,54 @@ func NewLabConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Comma
 			}
 
 			fmt.Println()
+
+			return nil
+		},
+	})
+
+	// config regenerate subcommand
+	cmd.AddCommand(&cobra.Command{
+		Use:   "regenerate",
+		Short: "Regenerate all service configuration files",
+		Long: `Regenerate all service configuration files from current .xcli.yaml settings.
+
+This is useful when you've changed settings in .xcli.yaml (like enabling/disabling
+networks) and need to update service configs without rebuilding or restarting.
+
+Regenerates configurations for:
+  - lab-backend (network routing, rate limiting, etc.)
+  - cbt-api (for each network)
+  - cbt engines (for each network, including model overrides)
+
+Note: This does NOT restart services. Use 'xcli lab restart <service>' to apply
+the new configs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			if cfg.Lab == nil {
+				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+			}
+
+			// Create orchestrator
+			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			if err != nil {
+				return fmt.Errorf("failed to create orchestrator: %w", err)
+			}
+
+			fmt.Println("Regenerating service configurations...")
+
+			if err := orch.GenerateConfigs(); err != nil {
+				return fmt.Errorf("failed to regenerate configs: %w", err)
+			}
+
+			fmt.Println("\n✓ All service configurations regenerated successfully")
+			fmt.Println("\nTo apply changes, restart affected services:")
+			fmt.Println("  xcli lab restart lab-backend")
+			fmt.Println("  xcli lab restart cbt-api-mainnet")
+			fmt.Println("  xcli lab restart cbt-mainnet")
 
 			return nil
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -362,7 +362,7 @@ func (c *LabConfig) EnabledNetworks() []NetworkConfig {
 // GetCBTPort returns the CBT port for a given network.
 func (c *LabConfig) GetCBTPort(network string) int {
 	for _, net := range c.Networks {
-		if net.Name == network && net.Enabled {
+		if net.Name == network {
 			return c.Ports.CBTBase + net.PortOffset
 		}
 	}
@@ -373,7 +373,7 @@ func (c *LabConfig) GetCBTPort(network string) int {
 // GetCBTAPIPort returns the cbt-api port for a given network.
 func (c *LabConfig) GetCBTAPIPort(network string) int {
 	for _, net := range c.Networks {
-		if net.Name == network && net.Enabled {
+		if net.Name == network {
 			return c.Ports.CBTAPIBase + net.PortOffset
 		}
 	}

--- a/pkg/configgen/generator.go
+++ b/pkg/configgen/generator.go
@@ -121,10 +121,11 @@ func (g *Generator) GenerateCBTAPIConfig(network string) (string, error) {
 // GenerateLabBackendConfig generates lab-backend configuration.
 func (g *Generator) GenerateLabBackendConfig() (string, error) {
 	networks := make([]map[string]interface{}, 0, len(g.cfg.Networks))
-	for _, net := range g.cfg.EnabledNetworks() {
+	for _, net := range g.cfg.Networks {
 		networks = append(networks, map[string]interface{}{
-			"Name": net.Name,
-			"Port": g.cfg.GetCBTAPIPort(net.Name),
+			"Name":    net.Name,
+			"Port":    g.cfg.GetCBTAPIPort(net.Name),
+			"Enabled": net.Enabled,
 		})
 	}
 

--- a/pkg/configgen/templates/lab-backend.yaml.tmpl
+++ b/pkg/configgen/templates/lab-backend.yaml.tmpl
@@ -56,6 +56,7 @@ rate_limiting:
 networks:
 {{- range .Networks }}
   - name: {{ .Name }}
+    enabled: {{ .Enabled }}
     target_url: "http://localhost:{{ .Port }}/api/v1"
 {{- end }}
 


### PR DESCRIPTION
Add `xcli lab config regenerate` command that rewrites all service configuration files from the current .xcli.yaml without rebuilding or restarting containers. This lets users update settings like network enable/disable flags and immediately regenerate the matching configs.

refactor(config): remove Enabled check from GetCBT*Port helpers

Ports are now always returned so that configs can be generated for disabled networks; the enabled flag is written into the generated lab-backend.yaml instead.

fix(configgen): include disabled networks in lab-backend config

The backend now receives the full list of networks with an explicit `enabled` field, allowing it to route only to active networks while still knowing about all defined ones.

fix(orchestrator): clean up orphaned processes on StopService

StopService now always attempts to kill any leftover child processes bound to the service’s ports, even when the main process is already gone.

fix(portutil): use lsof to detect listening processes

Replace the unreliable net.Listen check with direct lsof queries that find processes listening on specific interfaces and avoid false positives from TIME_WAIT sockets.