### PR TITLE
refactor(config): makes `xcli` work from any directory when installed globally

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -22,12 +22,12 @@ func NewConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Command 
 		Use:   "show",
 		Short: "Show current configuration (all stacks)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			data, err := yaml.Marshal(cfg)
+			data, err := yaml.Marshal(result.Config)
 			if err != nil {
 				return fmt.Errorf("failed to marshal config: %w", err)
 			}
@@ -43,12 +43,12 @@ func NewConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Command 
 		Use:   "validate",
 		Short: "Validate configuration (all stacks)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if err := cfg.Validate(); err != nil {
+			if err := result.Config.Validate(); err != nil {
 				fmt.Printf("✗ Configuration is invalid:\n  %v\n", err)
 
 				return err
@@ -57,12 +57,12 @@ func NewConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Command 
 			fmt.Println("✓ Configuration is valid")
 
 			// Show summary for each stack
-			if cfg.Lab != nil {
+			if result.Config.Lab != nil {
 				fmt.Printf("\nLab Stack:\n")
-				fmt.Printf("  Mode: %s\n", cfg.Lab.Mode)
+				fmt.Printf("  Mode: %s\n", result.Config.Lab.Mode)
 				fmt.Printf("  Networks: ")
 
-				for i, net := range cfg.Lab.EnabledNetworks() {
+				for i, net := range result.Config.Lab.EnabledNetworks() {
 					if i > 0 {
 						fmt.Print(", ")
 					}

--- a/pkg/commands/lab_build.go
+++ b/pkg/commands/lab_build.go
@@ -34,21 +34,21 @@ Examples:
   xcli lab build         # Build all projects
   xcli lab build --force # Force rebuild even if binaries exist`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
 			// Only validate repo paths for build command - infrastructure config not needed
-			if err := cfg.Lab.ValidateRepos(); err != nil {
+			if err := result.Config.Lab.ValidateRepos(); err != nil {
 				return fmt.Errorf("invalid lab configuration: %w", err)
 			}
 
-			buildMgr := builder.NewManager(log, cfg.Lab)
+			buildMgr := builder.NewManager(log, result.Config.Lab)
 
 			fmt.Println("building all lab repositories")
 

--- a/pkg/commands/lab_config.go
+++ b/pkg/commands/lab_config.go
@@ -23,16 +23,16 @@ func NewLabConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Comma
 		Use:   "show",
 		Short: "Show current lab configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			data, err := yaml.Marshal(cfg.Lab)
+			data, err := yaml.Marshal(result.Config.Lab)
 			if err != nil {
 				return fmt.Errorf("failed to marshal config: %w", err)
 			}
@@ -48,26 +48,26 @@ func NewLabConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Comma
 		Use:   "validate",
 		Short: "Validate lab configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			if err := cfg.Lab.Validate(); err != nil {
+			if err := result.Config.Lab.Validate(); err != nil {
 				fmt.Printf("✗ Lab configuration is invalid:\n  %v\n", err)
 
 				return err
 			}
 
 			fmt.Println("✓ Lab configuration is valid")
-			fmt.Printf("\nMode: %s\n", cfg.Lab.Mode)
+			fmt.Printf("\nMode: %s\n", result.Config.Lab.Mode)
 			fmt.Printf("Networks: ")
 
-			for i, net := range cfg.Lab.EnabledNetworks() {
+			for i, net := range result.Config.Lab.EnabledNetworks() {
 				if i > 0 {
 					fmt.Print(", ")
 				}
@@ -98,17 +98,17 @@ Regenerates configurations for:
 Note: This does NOT restart services. Use 'xcli lab restart <service>' to apply
 the new configs.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
 			// Create orchestrator
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_down.go
+++ b/pkg/commands/lab_down.go
@@ -26,16 +26,16 @@ The stack can be restarted with 'xcli lab up'.
 Example:
   xcli lab down`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_logs.go
+++ b/pkg/commands/lab_logs.go
@@ -18,12 +18,12 @@ func NewLabLogsCommand(log logrus.FieldLogger, configPath string) *cobra.Command
 		Short: "Show lab service logs",
 		Long:  `Show logs for all lab services or a specific service.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
@@ -32,7 +32,7 @@ func NewLabLogsCommand(log logrus.FieldLogger, configPath string) *cobra.Command
 				service = args[0]
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_mode.go
+++ b/pkg/commands/lab_mode.go
@@ -39,28 +39,28 @@ Examples:
 			}
 
 			// Load config
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
 			// Update mode and ClickHouse mode
 			// Note: We only change the mode fields, preserving any external credentials
 			// so users can switch back and forth without losing their config
-			oldMode := cfg.Lab.Mode
-			cfg.Lab.Mode = mode
+			oldMode := result.Config.Lab.Mode
+			result.Config.Lab.Mode = mode
 
 			hasExternalCredentials := true
 
 			if mode == constants.ModeHybrid {
-				cfg.Lab.Infrastructure.ClickHouse.Xatu.Mode = constants.InfraModeExternal
+				result.Config.Lab.Infrastructure.ClickHouse.Xatu.Mode = constants.InfraModeExternal
 
 				// Check if external credentials are configured
-				if cfg.Lab.Infrastructure.ClickHouse.Xatu.ExternalURL == "" {
+				if result.Config.Lab.Infrastructure.ClickHouse.Xatu.ExternalURL == "" {
 					hasExternalCredentials = false
 
 					fmt.Println("\n⚠ Warning: Switching to hybrid mode but no external ClickHouse URL configured")
@@ -73,16 +73,16 @@ Examples:
 					fmt.Println("          externalDatabase: \"default\"")
 				}
 			} else {
-				cfg.Lab.Infrastructure.ClickHouse.Xatu.Mode = constants.InfraModeLocal
+				result.Config.Lab.Infrastructure.ClickHouse.Xatu.Mode = constants.InfraModeLocal
 
 				// Inform user that external credentials are preserved
-				if oldMode == constants.ModeHybrid && cfg.Lab.Infrastructure.ClickHouse.Xatu.ExternalURL != "" {
+				if oldMode == constants.ModeHybrid && result.Config.Lab.Infrastructure.ClickHouse.Xatu.ExternalURL != "" {
 					fmt.Println("\n✓ External ClickHouse credentials preserved for future hybrid mode use")
 				}
 			}
 
 			// Save config
-			if err := cfg.Save(configPath); err != nil {
+			if err := result.Config.Save(result.ConfigPath); err != nil {
 				return fmt.Errorf("failed to save config: %w", err)
 			}
 
@@ -107,7 +107,7 @@ Examples:
 
 			_, _ = fmt.Scanln(&response)
 			if response == "y" || response == "Y" {
-				orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+				orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 				if err != nil {
 					return fmt.Errorf("failed to create orchestrator: %w", err)
 				}

--- a/pkg/commands/lab_ps.go
+++ b/pkg/commands/lab_ps.go
@@ -16,16 +16,16 @@ func NewLabPsCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
 		Short: "List running lab services",
 		Long:  `List all running lab services and their status.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_rebuild.go
+++ b/pkg/commands/lab_rebuild.go
@@ -43,17 +43,17 @@ Note: 'xatu-cbt' rebuild includes service restarts. Other rebuilds do NOT restar
 			project := args[0]
 
 			// Load config
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
 			// Create orchestrator
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_restart.go
+++ b/pkg/commands/lab_restart.go
@@ -17,16 +17,16 @@ func NewLabRestartCommand(log logrus.FieldLogger, configPath string) *cobra.Comm
 		Long:  `Restart a specific lab service.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_start.go
+++ b/pkg/commands/lab_start.go
@@ -27,16 +27,16 @@ Example:
   xcli lab start cbt-mainnet`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_stop.go
+++ b/pkg/commands/lab_stop.go
@@ -27,16 +27,16 @@ Example:
   xcli lab stop cbt-mainnet`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/commands/lab_up.go
+++ b/pkg/commands/lab_up.go
@@ -44,28 +44,28 @@ Examples:
   xcli lab up --rebuild    # Force rebuild everything`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Load config
-			cfg, err := config.Load(configPath)
+			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
 			// Check lab config exists
-			if cfg.Lab == nil {
+			if result.Config.Lab == nil {
 				return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
 			}
 
 			// Override mode if specified
 			if mode != "" {
-				cfg.Lab.Mode = mode
+				result.Config.Lab.Mode = mode
 			}
 
 			// Validate lab config
-			if validationErr := cfg.Lab.Validate(); validationErr != nil {
+			if validationErr := result.Config.Lab.Validate(); validationErr != nil {
 				return fmt.Errorf("invalid lab configuration: %w", validationErr)
 			}
 
 			// Create orchestrator
-			orch, err := orchestrator.NewOrchestrator(log, cfg.Lab)
+			orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to create orchestrator: %w", err)
 			}

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GlobalConfig represents the global xcli configuration stored in ~/.xcli/config.yaml.
+type GlobalConfig struct {
+	XCLIPath string `yaml:"xcliPath,omitempty"`
+}
+
+// LoadGlobalConfig loads the global config from ~/.xcli/config.yaml.
+func LoadGlobalConfig() (*GlobalConfig, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	globalConfigPath := filepath.Join(homeDir, ".xcli", "config.yaml")
+
+	// If file doesn't exist, return empty config
+	if _, statErr := os.Stat(globalConfigPath); os.IsNotExist(statErr) {
+		return &GlobalConfig{}, nil
+	}
+
+	data, err := os.ReadFile(globalConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read global config: %w", err)
+	}
+
+	var cfg GlobalConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse global config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// SaveGlobalConfig saves the global config to ~/.xcli/config.yaml.
+func SaveGlobalConfig(cfg *GlobalConfig) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	globalConfigDir := filepath.Join(homeDir, ".xcli")
+	if mkdirErr := os.MkdirAll(globalConfigDir, 0755); mkdirErr != nil {
+		return fmt.Errorf("failed to create global config directory: %w", err)
+	}
+
+	globalConfigPath := filepath.Join(globalConfigDir, "config.yaml")
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal global config: %w", err)
+	}
+
+	//nolint:gosec // Config file permissions are intentionally 0644 for readability
+	if err := os.WriteFile(globalConfigPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write global config: %w", err)
+	}
+
+	return nil
+}
+
+// SetXCLIPath sets the xcli installation path in the global config.
+func SetXCLIPath(path string) error {
+	// Make path absolute
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Verify the path has a .xcli.yaml file
+	configPath := filepath.Join(absPath, ".xcli.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return fmt.Errorf("no .xcli.yaml found in %s", absPath)
+	}
+
+	cfg := &GlobalConfig{
+		XCLIPath: absPath,
+	}
+
+	return SaveGlobalConfig(cfg)
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -35,11 +35,21 @@ type Orchestrator struct {
 }
 
 // NewOrchestrator creates a new Orchestrator instance.
-func NewOrchestrator(log logrus.FieldLogger, cfg *config.LabConfig) (*Orchestrator, error) {
-	stateDir := ".xcli"
+func NewOrchestrator(log logrus.FieldLogger, cfg *config.LabConfig, configPath string) (*Orchestrator, error) {
+	// Get absolute path of config file
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute config path: %w", err)
+	}
+
+	// State directory is in the same directory as the config file
+	configDir := filepath.Dir(absConfigPath)
+	stateDir := filepath.Join(configDir, ".xcli")
 
 	// Load user-provided CBT overrides if they exist
-	overrides, err := config.LoadCBTOverrides(constants.CBTOverridesFile)
+	overridesPath := filepath.Join(configDir, constants.CBTOverridesFile)
+
+	overrides, err := config.LoadCBTOverrides(overridesPath)
 	if err != nil {
 		log.WithError(err).Warn("failed to load user CBT overrides, using defaults")
 


### PR DESCRIPTION
Resolves issues where xcli only worked from within the project directory when installed globally.

  - Implement hybrid config search: upward -> child directories -> global config fallback
  - Use config file's directory for state (.xcli/) instead of current working directory
  - Auto-register xcli installation path on xcli lab init to `~/.xcli/config.yaml`
  - Simplify global config to single xcliPath field (removed project registry complexity)
