### PR TITLE
feat(builder): build CBT frontend before Go binary to embed assets

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,10 +89,11 @@ type VolumesConfig struct {
 
 // LabPortsConfig contains lab stack port assignments.
 type LabPortsConfig struct {
-	LabBackend  int `yaml:"labBackend"`
-	LabFrontend int `yaml:"labFrontend"`
-	CBTBase     int `yaml:"cbtBase"`
-	CBTAPIBase  int `yaml:"cbtApiBase"`
+	LabBackend      int `yaml:"labBackend"`
+	LabFrontend     int `yaml:"labFrontend"`
+	CBTBase         int `yaml:"cbtBase"`
+	CBTAPIBase      int `yaml:"cbtApiBase"`
+	CBTFrontendBase int `yaml:"cbtFrontendBase"`
 }
 
 // LabDevConfig contains lab stack development features.
@@ -148,10 +149,11 @@ func DefaultLab() *LabConfig {
 			RedisPort:          6380,
 		},
 		Ports: LabPortsConfig{
-			LabBackend:  8080,
-			LabFrontend: 5173,
-			CBTBase:     8081,
-			CBTAPIBase:  8091,
+			LabBackend:      8080,
+			LabFrontend:     5173,
+			CBTBase:         8081,
+			CBTAPIBase:      8091,
+			CBTFrontendBase: 8085,
 		},
 		Dev: LabDevConfig{
 			LabRebuildOnChange: false,
@@ -505,6 +507,17 @@ func (c *LabConfig) GetCBTAPIPort(network string) int {
 	for _, net := range c.Networks {
 		if net.Name == network {
 			return c.Ports.CBTAPIBase + net.PortOffset
+		}
+	}
+
+	return 0
+}
+
+// GetCBTFrontendPort returns the CBT frontend port for a given network.
+func (c *LabConfig) GetCBTFrontendPort(network string) int {
+	for _, net := range c.Networks {
+		if net.Name == network {
+			return c.Ports.CBTFrontendBase + net.PortOffset
 		}
 	}
 

--- a/pkg/configgen/generator.go
+++ b/pkg/configgen/generator.go
@@ -57,10 +57,13 @@ func (g *Generator) GenerateCBTConfig(network string, overridesPath string) (str
 		externalDatabase = g.cfg.Infrastructure.ClickHouse.Xatu.ExternalDatabase
 	}
 
+	frontendPort := g.cfg.GetCBTFrontendPort(network)
+
 	data := map[string]interface{}{
 		"Network":                    network,
 		"MetricsPort":                metricsPort,
 		"RedisDB":                    redisDB,
+		"FrontendPort":               frontendPort,
 		"IsHybrid":                   g.cfg.Mode == constants.ModeHybrid,
 		"XatuMode":                   g.cfg.Infrastructure.ClickHouse.Xatu.Mode,
 		"ExternalClickHouseURL":      g.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL,

--- a/pkg/configgen/templates/cbt.yaml.tmpl
+++ b/pkg/configgen/templates/cbt.yaml.tmpl
@@ -37,7 +37,8 @@ models:
     NETWORK: "{{ .Network }}"
 
 frontend:
-  enabled: false
+  enabled: true
+  addr: ":{{ .FrontendPort }}"
 
 scheduler:
   concurrency: 10

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -239,11 +239,12 @@ func (o *Orchestrator) Up(ctx context.Context, skipBuild bool, forceBuild bool) 
 
 	fmt.Println("\n✓ Stack is running!")
 	fmt.Println("\nServices:")
-	fmt.Printf("  Lab Frontend:  http://localhost:%d\n", o.cfg.Ports.LabFrontend)
-	fmt.Printf("  Lab Backend:   http://localhost:%d\n", o.cfg.Ports.LabBackend)
+	fmt.Printf("  Lab Frontend:     http://localhost:%d\n", o.cfg.Ports.LabFrontend)
+	fmt.Printf("  Lab Backend:      http://localhost:%d\n", o.cfg.Ports.LabBackend)
 
 	for _, net := range o.cfg.EnabledNetworks() {
-		fmt.Printf("  CBT API (%s): http://localhost:%d\n", net.Name, o.cfg.GetCBTAPIPort(net.Name))
+		fmt.Printf("  CBT API (%s):    http://localhost:%d\n", net.Name, o.cfg.GetCBTAPIPort(net.Name))
+		fmt.Printf("  CBT Frontend (%s): http://localhost:%d\n", net.Name, o.cfg.GetCBTFrontendPort(net.Name))
 	}
 
 	fmt.Println()
@@ -536,10 +537,13 @@ func (o *Orchestrator) checkPortConflicts() []portutil.PortConflict {
 	portsToCheck = append(portsToCheck, o.cfg.Ports.LabBackend)
 	portsToCheck = append(portsToCheck, o.cfg.Ports.LabFrontend)
 
-	// CBT and CBT API ports for each enabled network
+	// CBT, CBT API, and CBT frontend ports for each enabled network
 	for i, network := range enabledNetworks {
 		// CBT API service port
 		portsToCheck = append(portsToCheck, o.cfg.GetCBTAPIPort(network.Name))
+
+		// CBT frontend port
+		portsToCheck = append(portsToCheck, o.cfg.GetCBTFrontendPort(network.Name))
 
 		// CBT metrics port (9100 + network index)
 		portsToCheck = append(portsToCheck, 9100+i)
@@ -629,8 +633,8 @@ func (o *Orchestrator) getServicePorts(service string) []int {
 		// Check if it's a CBT or CBT-API service
 		for i, network := range o.cfg.EnabledNetworks() {
 			if service == "cbt-"+network.Name {
-				// CBT metrics port
-				return []int{9100 + i}
+				// CBT metrics port and frontend port
+				return []int{9100 + i, o.cfg.GetCBTFrontendPort(network.Name)}
 			}
 
 			if service == "cbt-api-"+network.Name {


### PR DESCRIPTION
feat(config): add CBTFrontendBase port and GetCBTFrontendPort helper
feat(configgen): expose CBT frontend port in generated config
feat(templates): enable CBT frontend and bind to dynamic port
feat(orchestrator): print CBT frontend URL and check its port