### PR TITLE
refactor: cmd cleanup

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -9,77 +9,157 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// NewConfigCommand creates the config command (global - shows all stacks).
-func NewConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Manage configuration (all stacks)",
-		Long:  `View and validate configuration for all stacks.`,
+const (
+	stackAll = "all"
+	stackLab = "lab"
+)
+
+// displayConfigForStack marshals and displays config for specified stack(s).
+// stack can be "all", "lab", or future stack names.
+func displayConfigForStack(cfg *config.Config, stack string) error {
+	var data []byte
+
+	var err error
+
+	switch stack {
+	case stackAll:
+		data, err = yaml.Marshal(cfg)
+	case stackLab:
+		if cfg.Lab == nil {
+			return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+		}
+
+		data, err = yaml.Marshal(cfg.Lab)
+	// Future stacks:
+	// case "contributoor":
+	//     if cfg.Contributoor == nil {
+	//         return fmt.Errorf("contributoor configuration not found")
+	//     }
+	//     data, err = yaml.Marshal(cfg.Contributoor)
+	default:
+		return fmt.Errorf("unknown stack: %s (supported: all, lab)", stack)
 	}
 
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+// validateConfigForStack validates and displays summary for specified stack(s).
+func validateConfigForStack(cfg *config.Config, stack string) error {
+	switch stack {
+	case stackAll:
+		if err := cfg.Validate(); err != nil {
+			fmt.Printf("✗ Configuration is invalid:\n  %v\n", err)
+
+			return err
+		}
+
+		fmt.Println("✓ Configuration is valid")
+
+		// Show summary for each configured stack
+		if cfg.Lab != nil {
+			displayLabSummary(cfg.Lab)
+		}
+		// Future: if cfg.Contributoor != nil { displayContributoorSummary() }
+
+	case stackLab:
+		if cfg.Lab == nil {
+			return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+		}
+
+		if err := cfg.Lab.Validate(); err != nil {
+			fmt.Printf("✗ Lab configuration is invalid:\n  %v\n", err)
+
+			return err
+		}
+
+		fmt.Println("✓ Lab configuration is valid")
+		displayLabSummary(cfg.Lab)
+
+	default:
+		return fmt.Errorf("unknown stack: %s (supported: all, lab)", stack)
+	}
+
+	return nil
+}
+
+// displayLabSummary shows a summary of lab configuration.
+func displayLabSummary(labCfg *config.LabConfig) {
+	fmt.Printf("\nLab Stack:\n")
+	fmt.Printf("  Mode: %s\n", labCfg.Mode)
+	fmt.Printf("  Networks: ")
+
+	for i, net := range labCfg.EnabledNetworks() {
+		if i > 0 {
+			fmt.Print(", ")
+		}
+
+		fmt.Print(net.Name)
+	}
+
+	fmt.Println()
+}
+
+// NewConfigCommand creates the config command (global - shows all stacks by default).
+func NewConfigCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+	var stackFilter string
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage configuration",
+		Long:  `View and validate configuration for all stacks or specific stack.`,
+	}
+
+	// Add --stack flag to parent command for inheritance
+	cmd.PersistentFlags().StringVar(&stackFilter, "stack", stackAll, "Filter by stack (all, lab)")
+
 	// config show subcommand
-	cmd.AddCommand(&cobra.Command{
+	showCmd := &cobra.Command{
 		Use:   "show",
-		Short: "Show current configuration (all stacks)",
+		Short: "Show current configuration",
+		Long: `Show current configuration for all stacks or filtered by --stack flag.
+
+Examples:
+  xcli config show              # Show all stacks (default)
+  xcli config show --stack=lab  # Show only lab stack
+  xcli config show --stack=all  # Show all stacks (explicit)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			data, err := yaml.Marshal(result.Config)
-			if err != nil {
-				return fmt.Errorf("failed to marshal config: %w", err)
-			}
-
-			fmt.Println(string(data))
-
-			return nil
+			return displayConfigForStack(result.Config, stackFilter)
 		},
-	})
+	}
 
 	// config validate subcommand
-	cmd.AddCommand(&cobra.Command{
+	validateCmd := &cobra.Command{
 		Use:   "validate",
-		Short: "Validate configuration (all stacks)",
+		Short: "Validate configuration",
+		Long: `Validate configuration for all stacks or filtered by --stack flag.
+
+Examples:
+  xcli config validate              # Validate all stacks (default)
+  xcli config validate --stack=lab  # Validate only lab stack
+  xcli config validate --stack=all  # Validate all stacks (explicit)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			if err := result.Config.Validate(); err != nil {
-				fmt.Printf("✗ Configuration is invalid:\n  %v\n", err)
-
-				return err
-			}
-
-			fmt.Println("✓ Configuration is valid")
-
-			// Show summary for each stack
-			if result.Config.Lab != nil {
-				fmt.Printf("\nLab Stack:\n")
-				fmt.Printf("  Mode: %s\n", result.Config.Lab.Mode)
-				fmt.Printf("  Networks: ")
-
-				for i, net := range result.Config.Lab.EnabledNetworks() {
-					if i > 0 {
-						fmt.Print(", ")
-					}
-
-					fmt.Print(net.Name)
-				}
-
-				fmt.Println()
-			}
-
-			// Future stacks can be added here
-			// if cfg.Contributoor != nil { ... }
-			// if cfg.Xatu != nil { ... }
-
-			return nil
+			return validateConfigForStack(result.Config, stackFilter)
 		},
-	})
+	}
+
+	cmd.AddCommand(showCmd)
+	cmd.AddCommand(validateCmd)
 
 	return cmd
 }

--- a/pkg/commands/lab.go
+++ b/pkg/commands/lab.go
@@ -20,26 +20,33 @@ The lab operates in two modes:
 Common workflows:
   1. Initial setup:
      xcli lab init           # Clone repos, check prerequisites
+     xcli lab check          # Verify environment is ready
      xcli lab up             # Start the stack
 
   2. Local development:
      (make code changes)
      xcli lab rebuild cbt-api   # Rebuild specific component
+     xcli lab status            # Check service status
 
   3. Mode switching:
      xcli lab mode hybrid    # Switch to hybrid mode
      xcli lab up             # Restart in new mode
+
+  4. Clean workspace:
+     xcli lab clean          # Remove all containers and artifacts
 
 Use 'xcli lab [command] --help' for more information about a command.`,
 	}
 
 	// Add lab subcommands
 	cmd.AddCommand(NewLabInitCommand(log, configPath))
+	cmd.AddCommand(NewLabCheckCommand(log, configPath))
 	cmd.AddCommand(NewLabUpCommand(log, configPath))
 	cmd.AddCommand(NewLabDownCommand(log, configPath))
+	cmd.AddCommand(NewLabCleanCommand(log, configPath))
 	cmd.AddCommand(NewLabBuildCommand(log, configPath))
 	cmd.AddCommand(NewLabRebuildCommand(log, configPath))
-	cmd.AddCommand(NewLabPsCommand(log, configPath))
+	cmd.AddCommand(NewLabStatusCommand(log, configPath))
 	cmd.AddCommand(NewLabLogsCommand(log, configPath))
 	cmd.AddCommand(NewLabStartCommand(log, configPath))
 	cmd.AddCommand(NewLabStopCommand(log, configPath))

--- a/pkg/commands/lab_build.go
+++ b/pkg/commands/lab_build.go
@@ -15,24 +15,34 @@ func NewLabBuildCommand(log logrus.FieldLogger, configPath string) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "build",
-		Short: "Build all lab projects",
-		Long: `Build all lab projects without starting services.
+		Short: "Build all lab projects from source without starting services",
+		Long: `Build all lab projects from source without starting services.
 
-This is useful for:
-  - Pre-building before 'xcli lab up --no-build'
-  - CI/CD pipelines
-  - Verifying builds without starting infrastructure
+Purpose:
+  This command is designed for CI/CD pipelines and pre-building scenarios.
+  It compiles all binaries but does NOT start any infrastructure or services.
 
-Projects built:
-  - xatu-cbt (Phase 0)
-  - CBT, lab-backend, lab (Phase 2, parallel)
-  - Protos and cbt-api (Phase 5-6)
+Use cases:
+  • Pre-building before 'xcli lab up --no-build' (faster startup)
+  • CI/CD build verification pipelines
+  • Checking for compilation errors without running services
+  • Creating clean builds from scratch
 
-For rebuilding specific projects during development, use 'xcli lab rebuild'.
+What gets built:
+  Phase 1: xatu-cbt (proto definitions)
+  Phase 2: CBT, lab-backend, lab-frontend (parallel)
+  Phase 3: Proto generation + cbt-api (requires xatu-cbt protos)
+
+Note: This does NOT generate configs or start services. For active development
+with running services, use 'xcli lab rebuild' instead.
+
+Key difference from 'rebuild':
+  • build  = Build everything, don't start services (CI/CD)
+  • rebuild = Build specific component + restart its services (development)
 
 Examples:
-  xcli lab build         # Build all projects
-  xcli lab build --force # Force rebuild even if binaries exist`,
+  xcli lab build         # Build all projects (skip if binaries exist)
+  xcli lab build --force # Force complete rebuild from scratch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := config.Load(configPath)
 			if err != nil {

--- a/pkg/commands/lab_check.go
+++ b/pkg/commands/lab_check.go
@@ -1,0 +1,207 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewLabCheckCommand creates the lab check command.
+func NewLabCheckCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Verify lab environment is ready",
+		Long: `Perform health checks on the lab environment without starting services.
+
+Verifies:
+  • Configuration file exists and is valid
+  • All required repositories are discovered and accessible
+  • Docker daemon is running and accessible
+  • Prerequisites are met (node_modules, .env files, etc.)
+  • Ports are available (not blocked by other processes)
+  • Disk space is sufficient
+
+This is useful for:
+  • Troubleshooting environment issues before 'xcli lab up'
+  • Verifying a new machine setup after 'xcli lab init'
+  • CI/CD pre-flight checks
+  • Documentation and onboarding
+
+Exit codes:
+  0 - All checks passed
+  1 - One or more checks failed
+
+Example:
+  xcli lab check`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLabCheck(cmd.Context(), log, configPath)
+		},
+	}
+}
+
+func runLabCheck(ctx context.Context, log logrus.FieldLogger, configPath string) error {
+	fmt.Println("Running lab environment health checks...")
+
+	allPassed := true
+
+	// Check 1: Configuration file
+	fmt.Print("✓ Checking configuration file... ")
+
+	result, err := config.Load(configPath)
+	if err != nil {
+		fmt.Printf("✗\n  Error: %v\n", err)
+
+		allPassed = false
+	} else if result.Config.Lab == nil {
+		fmt.Println("✗")
+		fmt.Println("  Error: Lab configuration not found")
+		fmt.Println("  Run: xcli lab init")
+
+		allPassed = false
+	} else {
+		fmt.Println("✓")
+	}
+
+	// Check 2: Configuration validity
+	if result != nil && result.Config.Lab != nil {
+		fmt.Print("✓ Validating configuration... ")
+
+		if err := result.Config.Lab.Validate(); err != nil {
+			fmt.Printf("✗\n  Error: %v\n", err)
+
+			allPassed = false
+		} else {
+			fmt.Println("✓")
+		}
+
+		// Check 3: Repository paths
+		fmt.Print("✓ Checking repository paths... ")
+
+		repoCheckPassed := true
+		repos := map[string]string{
+			"cbt":         result.Config.Lab.Repos.CBT,
+			"xatu-cbt":    result.Config.Lab.Repos.XatuCBT,
+			"cbt-api":     result.Config.Lab.Repos.CBTAPI,
+			"lab-backend": result.Config.Lab.Repos.LabBackend,
+			"lab":         result.Config.Lab.Repos.Lab,
+		}
+
+		missingRepos := []string{}
+
+		for name, path := range repos {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				missingRepos = append(missingRepos, fmt.Sprintf("%s (invalid path: %s)", name, path))
+				repoCheckPassed = false
+
+				continue
+			}
+
+			if _, err := os.Stat(absPath); os.IsNotExist(err) {
+				missingRepos = append(missingRepos, fmt.Sprintf("%s (not found: %s)", name, absPath))
+				repoCheckPassed = false
+			}
+		}
+
+		if !repoCheckPassed {
+			fmt.Println("✗")
+
+			for _, repo := range missingRepos {
+				fmt.Printf("  Missing: %s\n", repo)
+			}
+
+			fmt.Println("  Run: xcli lab init")
+
+			allPassed = false
+		} else {
+			fmt.Printf("✓ (all 5 repos found)\n")
+		}
+
+		// Check 4: Prerequisites (node_modules, etc.)
+		fmt.Print("✓ Checking prerequisites... ")
+
+		prereqPassed := true
+		prereqIssues := []string{}
+
+		// Check lab-frontend node_modules
+		labPath, _ := filepath.Abs(result.Config.Lab.Repos.Lab)
+		labNodeModules := filepath.Join(labPath, "node_modules")
+
+		if _, err := os.Stat(labNodeModules); os.IsNotExist(err) {
+			prereqIssues = append(prereqIssues, "lab: missing node_modules")
+			prereqPassed = false
+		}
+
+		// Check lab-backend .env
+		labBackendPath, _ := filepath.Abs(result.Config.Lab.Repos.LabBackend)
+		labBackendEnv := filepath.Join(labBackendPath, ".env")
+
+		if _, err := os.Stat(labBackendEnv); os.IsNotExist(err) {
+			prereqIssues = append(prereqIssues, "lab-backend: missing .env file")
+			prereqPassed = false
+		}
+
+		if !prereqPassed {
+			fmt.Println("✗")
+
+			for _, issue := range prereqIssues {
+				fmt.Printf("  Missing: %s\n", issue)
+			}
+
+			fmt.Println("  Run: xcli lab init")
+
+			allPassed = false
+		} else {
+			fmt.Println("✓")
+		}
+	}
+
+	// Check 5: Docker
+	fmt.Print("✓ Checking Docker daemon... ")
+
+	cmd := exec.CommandContext(ctx, "docker", "info")
+	if err := cmd.Run(); err != nil {
+		fmt.Println("✗")
+		fmt.Println("  Error: Docker daemon not accessible")
+		fmt.Println("  Ensure Docker Desktop is running")
+
+		allPassed = false
+	} else {
+		fmt.Println("✓")
+	}
+
+	// Check 6: Docker Compose
+	fmt.Print("✓ Checking Docker Compose... ")
+
+	cmd = exec.CommandContext(ctx, "docker", "compose", "version")
+	if err := cmd.Run(); err != nil {
+		fmt.Println("✗")
+		fmt.Println("  Error: Docker Compose not available")
+
+		allPassed = false
+	} else {
+		fmt.Println("✓")
+	}
+
+	// Summary
+	fmt.Println()
+
+	if allPassed {
+		fmt.Println("✓ All checks passed! Environment is ready.")
+		fmt.Println("\nNext steps:")
+		fmt.Println("  xcli lab up              # Start the lab stack")
+		fmt.Println("  xcli lab up --no-build   # Start without building (if already built)")
+
+		return nil
+	}
+
+	fmt.Println("✗ Some checks failed. Please resolve the issues above.")
+
+	return fmt.Errorf("environment checks failed")
+}

--- a/pkg/commands/lab_clean.go
+++ b/pkg/commands/lab_clean.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/ethpandaops/xcli/pkg/orchestrator"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewLabCleanCommand creates the lab clean command.
+func NewLabCleanCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Remove all generated artifacts and containers",
+		Long: `Completely clean the lab workspace by removing all generated artifacts.
+
+This will:
+  • Stop and remove all Docker containers
+  • Remove Docker volumes (data will be lost!)
+  • Delete generated configuration files (.xcli/ directory)
+  • Remove build artifacts (binaries in each repo)
+  • Clean proto-generated files
+
+Warning: This is a destructive operation!
+  • All data in ClickHouse and Redis will be lost
+  • You will need to rebuild with 'xcli lab build' or 'xcli lab up'
+  • Generated configs will need to be recreated
+
+This does NOT remove:
+  • Source code or repositories
+  • Your .xcli.yaml configuration file
+  • node_modules or other dependencies
+
+Use cases:
+  • Starting completely fresh after config changes
+  • Clearing disk space
+  • Troubleshooting persistent issues
+  • Switching between major configuration changes
+
+Examples:
+  xcli lab clean         # Interactive confirmation
+  xcli lab clean --force # Skip confirmation prompt`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLabClean(cmd.Context(), log, configPath, force)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runLabClean(ctx context.Context, log logrus.FieldLogger, configPath string, force bool) error {
+	result, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if result.Config.Lab == nil {
+		return fmt.Errorf("lab configuration not found - run 'xcli lab init' first")
+	}
+
+	// Confirm unless --force
+	if !force {
+		fmt.Println("⚠️  WARNING: This will remove all lab containers, volumes, and generated files!")
+		fmt.Println("\nThis includes:")
+		fmt.Println("  • All Docker containers and volumes (data will be lost)")
+		fmt.Println("  • Generated configs in .xcli/ directory")
+		fmt.Println("  • Build artifacts (binaries)")
+		fmt.Println("  • Proto-generated files")
+		fmt.Print("\nContinue? (y/N): ")
+
+		var response string
+
+		_, _ = fmt.Scanln(&response)
+
+		if response != "y" && response != "Y" {
+			fmt.Println("Cancelled.")
+
+			return nil
+		}
+	}
+
+	fmt.Println("\nCleaning lab workspace...")
+
+	// Step 1: Stop and remove containers/volumes
+	fmt.Println("\n[1/3] Stopping and removing Docker containers and volumes...")
+
+	orch, err := orchestrator.NewOrchestrator(log, result.Config.Lab, result.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	if err := orch.Down(ctx); err != nil {
+		fmt.Printf("⚠️  Warning: Failed to stop services: %v\n", err)
+		fmt.Println("Continuing with cleanup...")
+	}
+
+	// Step 2: Remove .xcli state directory
+	fmt.Println("\n[2/3] Removing generated configuration files...")
+
+	configDir := filepath.Dir(result.ConfigPath)
+	stateDir := filepath.Join(configDir, ".xcli")
+
+	if _, err := os.Stat(stateDir); err == nil {
+		if err := os.RemoveAll(stateDir); err != nil {
+			fmt.Printf("⚠️  Warning: Failed to remove %s: %v\n", stateDir, err)
+		} else {
+			fmt.Printf("  ✓ Removed %s\n", stateDir)
+		}
+	} else {
+		fmt.Println("  (no .xcli directory found)")
+	}
+
+	// Step 3: Remove build artifacts
+	fmt.Println("\n[3/3] Removing build artifacts...")
+
+	repos := map[string]string{
+		"cbt":         result.Config.Lab.Repos.CBT,
+		"xatu-cbt":    result.Config.Lab.Repos.XatuCBT,
+		"cbt-api":     result.Config.Lab.Repos.CBTAPI,
+		"lab-backend": result.Config.Lab.Repos.LabBackend,
+	}
+
+	for name, path := range repos {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			fmt.Printf("⚠️  Warning: Invalid path for %s: %v\n", name, err)
+
+			continue
+		}
+
+		// Remove common build artifacts
+		artifacts := []string{
+			filepath.Join(absPath, name),   // Binary with repo name
+			filepath.Join(absPath, "bin"),  // bin/ directory
+			filepath.Join(absPath, "dist"), // dist/ directory
+		}
+
+		for _, artifact := range artifacts {
+			if _, err := os.Stat(artifact); err == nil {
+				if err := os.RemoveAll(artifact); err != nil {
+					fmt.Printf("⚠️  Warning: Failed to remove %s: %v\n", artifact, err)
+				} else {
+					fmt.Printf("  ✓ Removed %s\n", artifact)
+				}
+			}
+		}
+	}
+
+	fmt.Println("\n✓ Lab workspace cleaned successfully!")
+	fmt.Println("\nNext steps:")
+	fmt.Println("  xcli lab build         # Rebuild all projects")
+	fmt.Println("  xcli lab up            # Build and start the stack")
+	fmt.Println("  xcli lab up --rebuild  # Force rebuild and start")
+
+	return nil
+}

--- a/pkg/commands/lab_mode.go
+++ b/pkg/commands/lab_mode.go
@@ -14,23 +14,30 @@ import (
 func NewLabModeCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mode <local|hybrid>",
-		Short: "Switch between local and hybrid modes",
-		Long: `Switch the lab stack between local and hybrid modes.
+		Short: "Switch deployment mode between fully local and hybrid external data source",
+		Long: `Switch deployment mode between fully local and hybrid external data source.
 
 Modes:
-  local  - Fully local stack with no external dependencies.
-           All services (ClickHouse, Redis) run locally in Docker.
+  local  - Complete local development environment (default)
+           • All services run locally in Docker
+           • Local Xatu ClickHouse for data source
+           • Local CBT ClickHouse for processing
+           • No external dependencies required
+           • Best for: Isolated development, testing, demos
 
-  hybrid - Uses external ClickHouse database for data source.
-           Local ClickHouse CBT and Redis for processing.
-           Requires external_clickhouse configuration in .xcli.yaml.
+  hybrid - Mixed local processing with external production data
+           • External Xatu ClickHouse (production data source)
+           • Local CBT ClickHouse (local processing and storage)
+           • Local Redis for caching
+           • Requires: external_clickhouse configuration in .xcli.yaml
+           • Best for: Testing against production data, debugging live issues
 
-After switching modes, restart the stack with 'xcli lab up' for changes
-to take effect.
+After switching modes, restart the stack for changes to take effect:
+  xcli lab down && xcli lab up
 
 Examples:
-  xcli lab mode local        # Switch to local mode
-  xcli lab mode hybrid       # Switch to hybrid mode`,
+  xcli lab mode local        # Switch to fully local mode
+  xcli lab mode hybrid       # Switch to hybrid mode (requires external ClickHouse config)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode := args[0]

--- a/pkg/commands/lab_rebuild.go
+++ b/pkg/commands/lab_rebuild.go
@@ -16,26 +16,47 @@ func NewLabRebuildCommand(log logrus.FieldLogger, configPath string) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:   "rebuild [project]",
-		Short: "Rebuild specific project(s) for local development",
-		Long: `Rebuild one or more projects without full stack restart.
+		Short: "Rebuild specific components during active development with automatic service restarts",
+		Long: `Rebuild specific components during active development with automatic service restarts.
 
-Useful for local development when you've made changes and need to rebuild
-specific components. Much faster than 'xcli lab down && xcli lab up'.
+Purpose:
+  This command is designed for rapid iteration during local development.
+  It rebuilds ONLY what changed and automatically restarts affected services.
+
+Use cases:
+  • You modified code and need to test changes immediately
+  • You added/changed models in xatu-cbt and need full regeneration
+  • You updated API endpoints in cbt-api
+  • Fast development loop without full 'down && up' cycle
+
+Key difference from 'build':
+  • build  = Build everything, don't start services (CI/CD)
+  • rebuild = Build specific component + restart its services (development)
 
 Supported projects:
-  xatu-cbt     - Regenerate protos + rebuild cbt-api + regenerate configs + restart services + regenerate lab-frontend types
-                 (Use this when you add/modify models in xatu-cbt)
-  cbt          - Rebuild CBT + restart CBT services
-  cbt-api      - Regenerate protos + rebuild cbt-api + restart cbt-api services
-  lab-backend  - Rebuild lab-backend + restart lab-backend service
-  lab-frontend - Regenerate frontend API types from cbt-api OpenAPI spec + restart lab-frontend
-  all          - Rebuild all projects (CBT, lab-backend, lab)
+  xatu-cbt     - Full model update workflow
+                 (protos → cbt-api → configs → restart → frontend types)
+                 Use when: You add/modify models in xatu-cbt
+
+  cbt          - Rebuild CBT binary + restart all CBT services
+                 Use when: You modify CBT engine code
+
+  cbt-api      - Regenerate protos + rebuild + restart all cbt-api services
+                 Use when: You modify cbt-api endpoints
+
+  lab-backend  - Rebuild + restart lab-backend service
+                 Use when: You modify lab-backend code
+
+  lab-frontend - Regenerate API types + restart lab-frontend
+                 Use when: cbt-api OpenAPI spec changed
+
+  all          - Rebuild everything in parallel + restart all services
+                 Use when: Multiple changes across projects
 
 Examples:
-  xcli lab rebuild xatu-cbt         # Full model update workflow (proto → cbt-api → configs → restart)
-  xcli lab rebuild cbt-api          # Regenerate protos + rebuild cbt-api + restart
-  xcli lab rebuild cbt --verbose    # Rebuild CBT with verbose output + restart
-  xcli lab rebuild all              # Rebuild everything (parallel)
+  xcli lab rebuild xatu-cbt          # Full model update (most common)
+  xcli lab rebuild cbt               # Quick CBT engine iteration
+  xcli lab rebuild lab-backend -v    # Rebuild with verbose output
 
 Note: All rebuild commands automatically restart their respective services if running.`,
 		Args: cobra.ExactArgs(1),

--- a/pkg/commands/lab_status.go
+++ b/pkg/commands/lab_status.go
@@ -9,12 +9,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewLabPsCommand creates the lab ps command.
-func NewLabPsCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
+// NewLabStatusCommand creates the lab status command.
+func NewLabStatusCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "ps",
-		Short: "List running lab services",
-		Long:  `List all running lab services and their status.`,
+		Use:   "status",
+		Short: "Show lab stack status",
+		Long: `Display status of all lab services and infrastructure.
+
+Shows:
+  • Running services and their states
+  • Port bindings
+  • Container health
+  • Infrastructure status (ClickHouse, Redis)
+
+Example:
+  xcli lab status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := config.Load(configPath)
 			if err != nil {


### PR DESCRIPTION
Improves xcli command structure with better naming, reduced code duplication, and new diagnostic tools.

  ### Changes

  **New Commands**
  - `xcli lab check` - Pre-flight environment verification (repos, Docker, config, prerequisites)
  - `xcli lab clean` - Complete workspace cleanup (containers, volumes, build artifacts)
  - `xcli lab status` - Renamed from `ps` for clarity

  **Config Consolidation**
  - Added `--stack` flag to `xcli config` commands
  - Shared helper functions reduce ~80 lines of duplicate code
  - Both `xcli config show --stack=lab` and `xcli lab config show` work (backward compatible)

  **Breaking Changes**
  - `xcli lab ps` removed - use `xcli lab status` instead