### PR TITLE
refactor(cli): remove --force, --no-build and --rebuild flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,9 @@ Services:
 ```bash
 xcli lab init                    # Initialize configuration
 xcli lab check                   # Verify environment (repos, Docker, config)
-xcli lab up                      # Start all services
-xcli lab up --rebuild            # Force rebuild before starting
-xcli lab up --no-build           # Skip build (fail if binaries missing)
+xcli lab up                      # Start all services (always rebuilds)
 xcli lab down                    # Stop and remove containers/volumes
 xcli lab clean                   # Remove all containers, volumes, and build artifacts
-xcli lab clean --force           # Skip confirmation prompt
 xcli lab status                  # Show service status
 ```
 
@@ -59,8 +56,7 @@ xcli lab status                  # Show service status
 
 ```bash
 # Build (CI/CD, pre-building without starting services)
-xcli lab build                   # Build all binaries (skips if exist)
-xcli lab build -f                # Force rebuild all
+xcli lab build                   # Build all binaries
 
 # Rebuild (development - rebuilds and auto-restarts services)
 xcli lab rebuild <target>        # Rebuild specific component + restart

--- a/pkg/commands/lab_up.go
+++ b/pkg/commands/lab_up.go
@@ -17,8 +17,6 @@ import (
 func NewLabUpCommand(log logrus.FieldLogger, configPath string) *cobra.Command {
 	var (
 		mode    string
-		noBuild bool
-		rebuild bool
 		verbose bool
 	)
 
@@ -33,16 +31,15 @@ already, run 'xcli lab init' first to ensure all prerequisites are met.
 The stack starts in the configured mode (local or hybrid). Use 'xcli lab mode'
 to switch between modes.
 
+This command always rebuilds all projects to ensure everything is up to date.
+
 Flags:
-  --no-build  Skip building projects (use existing builds)
-  --rebuild   Force rebuild all projects from scratch
   --verbose   Enable verbose output for all operations
   --mode      Override mode for this run (local or hybrid)
 
 Examples:
-  xcli lab up              # Normal startup
-  xcli lab up --verbose    # Startup with detailed output
-  xcli lab up --rebuild    # Force rebuild everything`,
+  xcli lab up              # Start all services (always rebuilds)
+  xcli lab up --verbose    # Startup with detailed output`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Load config
 			result, err := config.Load(configPath)
@@ -95,14 +92,12 @@ Examples:
 				os.Exit(0)
 			}()
 
-			// Start everything
-			return orch.Up(cmd.Context(), noBuild, rebuild)
+			// Always rebuild (skipBuild=false, forceBuild=true)
+			return orch.Up(cmd.Context(), false, true)
 		},
 	}
 
 	cmd.Flags().StringVarP(&mode, "mode", "m", "", "Override mode (local or hybrid)")
-	cmd.Flags().BoolVar(&noBuild, "no-build", false, "Skip building, fail if binaries are missing")
-	cmd.Flags().BoolVar(&rebuild, "rebuild", false, "Force rebuild all binaries even if they exist")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show all build/setup command output (default: errors only)")
 
 	return cmd


### PR DESCRIPTION
Simplify the CLI surface by always rebuilding on `lab up` and `lab build` and always prompting on `lab clean`. This eliminates confusion about when binaries are stale and guarantees consistent, reproducible builds.