### PR TITLE
feat(clickhouse): wire external Xatu credentials through init and infra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/wagiedev/claude-agent-sdk-go v0.0.3
 	golang.org/x/sync v0.20.0
+	golang.org/x/term v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -109,7 +110,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )

--- a/pkg/builder/manager.go
+++ b/pkg/builder/manager.go
@@ -350,8 +350,21 @@ func (m *Manager) GenerateXatuCBTProtosWithResult(ctx context.Context) *diagnost
 	if m.cfg.Infrastructure.ClickHouse.Xatu.Mode == constants.InfraModeExternal {
 		env = append(env, "XATU_SOURCE=external")
 
-		if m.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL != "" {
-			env = append(env, fmt.Sprintf("XATU_URL=%s", m.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL))
+		// Embed any separately-configured credentials into the URL, since
+		// downstream tooling reads them only from the URL itself.
+		xatuURL, urlErr := m.cfg.Infrastructure.ClickHouse.Xatu.ExternalURLWithCredentials()
+		if urlErr != nil {
+			return &diagnostic.BuildResult{
+				Phase:    diagnostic.PhaseProtoGen,
+				Service:  "xatu-cbt",
+				Success:  false,
+				Error:    urlErr,
+				ErrorMsg: urlErr.Error(),
+			}
+		}
+
+		if xatuURL != "" {
+			env = append(env, fmt.Sprintf("XATU_URL=%s", xatuURL))
 		}
 
 		m.log.WithField("xatu_source", "external").Debug("passing external mode to proto generation")

--- a/pkg/builder/manager.go
+++ b/pkg/builder/manager.go
@@ -46,11 +46,11 @@ func (m *Manager) SetVerbose(verbose bool) {
 // CheckBinariesExist checks if all required binaries exist.
 func (m *Manager) CheckBinariesExist() map[string]bool {
 	return map[string]bool{
-		"xatu-cbt":    m.binaryExists(filepath.Join(m.cfg.Repos.XatuCBT, "bin", "xatu-cbt")),
-		"cbt":         m.binaryExists(filepath.Join(m.cfg.Repos.CBT, "bin", "cbt")),
-		"cbt-api":     m.binaryExists(filepath.Join(m.cfg.Repos.CBTAPI, "bin", "server")),
-		"lab-backend": m.binaryExists(filepath.Join(m.cfg.Repos.LabBackend, "bin", "lab-backend")),
-		"lab-deps":    m.dirExists(filepath.Join(m.cfg.Repos.Lab, "node_modules")),
+		constants.RepoXatuCBT: m.binaryExists(filepath.Join(m.cfg.Repos.XatuCBT, "bin", constants.RepoXatuCBT)),
+		constants.RepoCBT:     m.binaryExists(filepath.Join(m.cfg.Repos.CBT, "bin", constants.RepoCBT)),
+		constants.RepoCBTAPI:  m.binaryExists(filepath.Join(m.cfg.Repos.CBTAPI, "bin", "server")),
+		"lab-backend":         m.binaryExists(filepath.Join(m.cfg.Repos.LabBackend, "bin", "lab-backend")),
+		"lab-deps":            m.dirExists(filepath.Join(m.cfg.Repos.Lab, "node_modules")),
 	}
 }
 
@@ -69,9 +69,9 @@ func (m *Manager) BuildAll(ctx context.Context, force bool) error {
 
 	// Build CBT in parallel
 	g.Go(func() error {
-		spinner := m.startBuildSpinner("cbt")
+		spinner := m.startBuildSpinner(constants.RepoCBT)
 		err := m.BuildCBT(ctx, force)
-		m.finishBuildSpinner(spinner, "cbt", err, progressBar)
+		m.finishBuildSpinner(spinner, constants.RepoCBT, err, progressBar)
 
 		return err
 	})
@@ -119,30 +119,30 @@ func (m *Manager) BuildXatuCBT(ctx context.Context, force bool) error {
 
 // BuildXatuCBTWithResult builds xatu-cbt binary and returns BuildResult.
 func (m *Manager) BuildXatuCBTWithResult(ctx context.Context, force bool) *diagnostic.BuildResult {
-	binary := filepath.Join(m.cfg.Repos.XatuCBT, "bin", "xatu-cbt")
+	binary := filepath.Join(m.cfg.Repos.XatuCBT, "bin", constants.RepoXatuCBT)
 
 	if !force && m.binaryExists(binary) {
-		m.log.WithField("repo", "xatu-cbt").Info("binary exists, skipping build")
+		m.log.WithField("repo", constants.RepoXatuCBT).Info("binary exists, skipping build")
 
 		now := time.Now()
 
 		return &diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "xatu-cbt",
+			Service:   constants.RepoXatuCBT,
 			Success:   true,
 			StartTime: now,
 			EndTime:   now,
 		}
 	}
 
-	m.log.WithField("repo", "xatu-cbt").Info("building project")
+	m.log.WithField("repo", constants.RepoXatuCBT).Info("building project")
 
-	return m.runMakeWithResult(ctx, m.cfg.Repos.XatuCBT, "build", diagnostic.PhaseBuild, "xatu-cbt")
+	return m.runMakeWithResult(ctx, m.cfg.Repos.XatuCBT, "build", diagnostic.PhaseBuild, constants.RepoXatuCBT)
 }
 
 // XatuCBTBinaryExists checks if the xatu-cbt binary exists.
 func (m *Manager) XatuCBTBinaryExists() bool {
-	binary := filepath.Join(m.cfg.Repos.XatuCBT, "bin", "xatu-cbt")
+	binary := filepath.Join(m.cfg.Repos.XatuCBT, "bin", constants.RepoXatuCBT)
 
 	return m.binaryExists(binary)
 }
@@ -156,23 +156,23 @@ func (m *Manager) BuildCBT(ctx context.Context, force bool) error {
 
 // BuildCBTWithResult builds the cbt binary and returns BuildResult.
 func (m *Manager) BuildCBTWithResult(ctx context.Context, force bool) *diagnostic.BuildResult {
-	binary := filepath.Join(m.cfg.Repos.CBT, "bin", "cbt")
+	binary := filepath.Join(m.cfg.Repos.CBT, "bin", constants.RepoCBT)
 
 	if !force && m.binaryExists(binary) {
-		m.log.WithField("repo", "cbt").Info("binary exists, skipping build")
+		m.log.WithField("repo", constants.RepoCBT).Info("binary exists, skipping build")
 
 		now := time.Now()
 
 		return &diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "cbt",
+			Service:   constants.RepoCBT,
 			Success:   true,
 			StartTime: now,
 			EndTime:   now,
 		}
 	}
 
-	m.log.WithField("repo", "cbt").Info("building project")
+	m.log.WithField("repo", constants.RepoCBT).Info("building project")
 
 	// Build CBT frontend first (required for embedding in binary)
 	if err := m.buildCBTFrontend(ctx, force); err != nil {
@@ -180,7 +180,7 @@ func (m *Manager) BuildCBTWithResult(ctx context.Context, force bool) *diagnosti
 
 		return &diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "cbt",
+			Service:   constants.RepoCBT,
 			Success:   false,
 			Error:     fmt.Errorf("failed to build CBT frontend: %w", err),
 			ErrorMsg:  fmt.Sprintf("failed to build CBT frontend: %v", err),
@@ -196,7 +196,7 @@ func (m *Manager) BuildCBTWithResult(ctx context.Context, force bool) *diagnosti
 
 		return &diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "cbt",
+			Service:   constants.RepoCBT,
 			Success:   false,
 			Error:     fmt.Errorf("failed to create bin directory: %w", err),
 			ErrorMsg:  fmt.Sprintf("failed to create bin directory: %v", err),
@@ -208,7 +208,7 @@ func (m *Manager) BuildCBTWithResult(ctx context.Context, force bool) *diagnosti
 	cmd := exec.CommandContext(ctx, "go", "build", "-o", binary, ".")
 	cmd.Dir = m.cfg.Repos.CBT
 
-	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseBuild, "cbt")
+	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseBuild, constants.RepoCBT)
 }
 
 // BuildCBTAPI builds cbt-api with proto generation
@@ -231,29 +231,29 @@ func (m *Manager) BuildCBTAPIWithResult(ctx context.Context, force bool) *diagno
 	binary := filepath.Join(m.cfg.Repos.CBTAPI, "bin", "server")
 
 	if !force && m.binaryExists(binary) {
-		m.log.WithField("repo", "cbt-api").Info("binary exists, skipping build")
+		m.log.WithField("repo", constants.RepoCBTAPI).Info("binary exists, skipping build")
 
 		now := time.Now()
 
 		return &diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "cbt-api",
+			Service:   constants.RepoCBTAPI,
 			Success:   true,
 			StartTime: now,
 			EndTime:   now,
 		}
 	}
 
-	m.log.WithField("repo", "cbt-api").Info("building project")
+	m.log.WithField("repo", constants.RepoCBTAPI).Info("building project")
 
 	// Generate OpenAPI and other code (requires proto to be run first)
-	genResult := m.runMakeWithResult(ctx, m.cfg.Repos.CBTAPI, "generate", diagnostic.PhaseBuild, "cbt-api")
+	genResult := m.runMakeWithResult(ctx, m.cfg.Repos.CBTAPI, "generate", diagnostic.PhaseBuild, constants.RepoCBTAPI)
 	if !genResult.Success {
 		return genResult
 	}
 
 	// Build the binary
-	return m.runMakeWithResult(ctx, m.cfg.Repos.CBTAPI, "build-binary", diagnostic.PhaseBuild, "cbt-api")
+	return m.runMakeWithResult(ctx, m.cfg.Repos.CBTAPI, "build-binary", diagnostic.PhaseBuild, constants.RepoCBTAPI)
 }
 
 // BuildLabBackend builds lab-backend binary.
@@ -336,7 +336,7 @@ func (m *Manager) GenerateXatuCBTProtos(ctx context.Context) error {
 
 // GenerateXatuCBTProtosWithResult generates protobuf files for xatu-cbt and returns BuildResult.
 func (m *Manager) GenerateXatuCBTProtosWithResult(ctx context.Context) *diagnostic.BuildResult {
-	m.log.WithField("repo", "xatu-cbt").Info("generating protos")
+	m.log.WithField("repo", constants.RepoXatuCBT).Info("generating protos")
 
 	// Clean generated proto files before regenerating to avoid stale files
 	if err := m.CleanXatuCBTProtos(); err != nil {
@@ -356,7 +356,7 @@ func (m *Manager) GenerateXatuCBTProtosWithResult(ctx context.Context) *diagnost
 		if urlErr != nil {
 			return &diagnostic.BuildResult{
 				Phase:    diagnostic.PhaseProtoGen,
-				Service:  "xatu-cbt",
+				Service:  constants.RepoXatuCBT,
 				Success:  false,
 				Error:    urlErr,
 				ErrorMsg: urlErr.Error(),
@@ -374,12 +374,12 @@ func (m *Manager) GenerateXatuCBTProtosWithResult(ctx context.Context) *diagnost
 	cmd.Dir = m.cfg.Repos.XatuCBT
 	cmd.Env = env
 
-	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseProtoGen, "xatu-cbt")
+	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseProtoGen, constants.RepoXatuCBT)
 }
 
 // CleanXatuCBTProtos removes generated proto files from xatu-cbt.
 func (m *Manager) CleanXatuCBTProtos() error {
-	m.log.WithField("repo", "xatu-cbt").Info("cleaning generated proto files")
+	m.log.WithField("repo", constants.RepoXatuCBT).Info("cleaning generated proto files")
 
 	// xatu-cbt generates protos to pkg/proto/clickhouse/
 	protoDir := filepath.Join(m.cfg.Repos.XatuCBT, "pkg", "proto", "clickhouse")
@@ -405,7 +405,7 @@ func (m *Manager) GenerateProtosWithResult(ctx context.Context) *diagnostic.Buil
 	network := m.cfg.EnabledNetworks()[0]
 
 	m.log.WithFields(logrus.Fields{
-		"repo":    "cbt-api",
+		"repo":    constants.RepoCBTAPI,
 		"network": network.Name,
 	}).Info("generating protos")
 
@@ -423,13 +423,13 @@ func (m *Manager) GenerateProtosWithResult(ctx context.Context) *diagnostic.Buil
 
 	cmd.Env = append(os.Environ(), fmt.Sprintf("CONFIG_FILE=%s", configPath))
 
-	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseProtoGen, "cbt-api")
+	return executil.RunCmdWithResult(cmd, m.verbose, diagnostic.PhaseProtoGen, constants.RepoCBTAPI)
 }
 
 // CleanCBTAPIGenerated removes all generated files from cbt-api.
 // This includes proto files, handlers, server implementation, and OpenAPI specs.
 func (m *Manager) CleanCBTAPIGenerated() error {
-	m.log.WithField("repo", "cbt-api").Info("cleaning generated files")
+	m.log.WithField("repo", constants.RepoCBTAPI).Info("cleaning generated files")
 
 	// Files and directories to remove (matches cbt-api Makefile clean target)
 	toRemove := []string{

--- a/pkg/cc/api.go
+++ b/pkg/cc/api.go
@@ -21,6 +21,25 @@ import (
 
 const gitCacheTTL = 2 * time.Minute
 
+const (
+	keyError     = "error"
+	keyService   = "service"
+	keyStatus    = "status"
+	keyText      = "text"
+	keyProvider  = "provider"
+	keySessionID = "sessionId"
+	keyRequestID = "requestId"
+	keyOK        = "ok"
+	keyPhase     = "phase"
+	keyMessage   = "message"
+	keyBase64    = "base64"
+	cmdDocker    = "docker"
+
+	errMsgDiagnoseSessionNotFound = "diagnose session not found"
+	errMsgSessionServiceMismatch  = "session/service mismatch"
+	errMsgServiceNameRequired     = "service name required"
+)
+
 // gitCache holds the last successful git status response to avoid
 // repeated expensive git operations on every poll.
 type gitCache struct {
@@ -230,7 +249,7 @@ func (a *apiHandler) handlePostServiceAction(
 	name := r.PathValue("name")
 	if name == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "service name required",
+			keyError: errMsgServiceNameRequired,
 		})
 
 		return
@@ -252,7 +271,7 @@ func (a *apiHandler) handlePostServiceAction(
 		err = a.backend.RebuildService(ctx, name)
 	default:
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "unknown action: " + action,
+			keyError: "unknown action: " + action,
 		})
 
 		return
@@ -260,19 +279,19 @@ func (a *apiHandler) handlePostServiceAction(
 
 	if err != nil {
 		a.log.WithError(err).WithFields(logrus.Fields{
-			"service": name,
-			"action":  action,
+			keyService: name,
+			"action":   action,
 		}).Error("Service action failed")
 
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": "ok",
+		keyStatus: keyOK,
 	})
 }
 
@@ -286,7 +305,7 @@ func (a *apiHandler) handleGetServiceLogs(
 	name := r.PathValue("name")
 	if name == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "service name required",
+			keyError: errMsgServiceNameRequired,
 		})
 
 		return
@@ -297,7 +316,7 @@ func (a *apiHandler) handleGetServiceLogs(
 	f, err := os.Open(logPath)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{
-			"error": "log file not found",
+			keyError: "log file not found",
 		})
 
 		return

--- a/pkg/cc/api_config.go
+++ b/pkg/cc/api_config.go
@@ -77,7 +77,7 @@ func (a *apiHandler) handleGetLabConfig(w http.ResponseWriter, _ *http.Request) 
 	resp, err := a.backend.GetEditableConfig()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -91,7 +91,7 @@ func (a *apiHandler) handlePutLabConfig(w http.ResponseWriter, r *http.Request) 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("failed to read body: %v", err),
+			keyError: fmt.Sprintf("failed to read body: %v", err),
 		})
 
 		return
@@ -103,7 +103,7 @@ func (a *apiHandler) handlePutLabConfig(w http.ResponseWriter, r *http.Request) 
 		a.mu.Unlock()
 
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -111,7 +111,7 @@ func (a *apiHandler) handlePutLabConfig(w http.ResponseWriter, r *http.Request) 
 
 	a.mu.Unlock()
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{keyStatus: keyOK})
 }
 
 // handleGetConfigFiles lists generated config files via the backend.
@@ -122,7 +122,7 @@ func (a *apiHandler) handleGetConfigFiles(
 	files, err := a.backend.GetConfigFiles()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -141,7 +141,7 @@ func (a *apiHandler) handleGetConfigFile(
 	resp, err := a.backend.GetConfigFile(name)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -163,7 +163,7 @@ func (a *apiHandler) handlePutConfigFileOverride(
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("invalid request body: %v", err),
+			keyError: fmt.Sprintf("invalid request body: %v", err),
 		})
 
 		return
@@ -171,13 +171,13 @@ func (a *apiHandler) handlePutConfigFileOverride(
 
 	if err := a.backend.PutConfigFileOverride(name, req.Content); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{keyStatus: keyOK})
 }
 
 // handleDeleteConfigFileOverride removes a custom override for a config file.
@@ -189,13 +189,13 @@ func (a *apiHandler) handleDeleteConfigFileOverride(
 
 	if err := a.backend.DeleteConfigFileOverride(name); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{keyStatus: keyOK})
 }
 
 // handleGetOverrides returns the CBT overrides state via the backend.
@@ -209,7 +209,7 @@ func (a *apiHandler) handleGetOverrides(
 	resp, err := a.backend.GetOverrides()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -226,7 +226,7 @@ func (a *apiHandler) handlePutOverrides(
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("failed to read body: %v", err),
+			keyError: fmt.Sprintf("failed to read body: %v", err),
 		})
 
 		return
@@ -238,7 +238,7 @@ func (a *apiHandler) handlePutOverrides(
 		a.mu.Unlock()
 
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+			keyError: err.Error(),
 		})
 
 		return
@@ -246,7 +246,7 @@ func (a *apiHandler) handlePutOverrides(
 
 	a.mu.Unlock()
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{keyStatus: keyOK})
 }
 
 // handlePostRegenerate triggers config regeneration via the backend.
@@ -256,7 +256,7 @@ func (a *apiHandler) handlePostRegenerate(
 ) {
 	if err := a.backend.Regenerate(r.Context()); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": fmt.Sprintf(
+			keyError: fmt.Sprintf(
 				"failed to regenerate configs: %v", err,
 			),
 		})
@@ -265,11 +265,11 @@ func (a *apiHandler) handlePostRegenerate(
 	}
 
 	a.sseHub.Broadcast("config_regenerated", map[string]string{
-		"status": "ok",
+		keyStatus: keyOK,
 	})
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": "ok",
+		keyStatus: keyOK,
 	})
 }
 

--- a/pkg/cc/api_diagnose.go
+++ b/pkg/cc/api_diagnose.go
@@ -68,18 +68,18 @@ func (a *apiHandler) handleGetAIProviders(w http.ResponseWriter, r *http.Request
 
 // handleGetDiagnoseAvailable returns whether the selected provider is available.
 func (a *apiHandler) handleGetDiagnoseAvailable(w http.ResponseWriter, r *http.Request) {
-	provider := a.providerFromString(r.URL.Query().Get("provider"))
+	provider := a.providerFromString(r.URL.Query().Get(keyProvider))
 
 	engine, err := ai.NewEngine(provider, a.log)
 	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"available": false, "provider": provider})
+		writeJSON(w, http.StatusOK, map[string]any{"available": false, keyProvider: provider})
 
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"available": engine.IsAvailable(),
-		"provider":  provider,
+		keyProvider: provider,
 	})
 }
 
@@ -87,36 +87,36 @@ func (a *apiHandler) handleGetDiagnoseAvailable(w http.ResponseWriter, r *http.R
 func (a *apiHandler) handlePostDiagnose(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service name required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgServiceNameRequired})
 
 		return
 	}
 
-	provider := a.providerFromString(r.URL.Query().Get("provider"))
+	provider := a.providerFromString(r.URL.Query().Get(keyProvider))
 
 	engine, err := ai.NewEngine(provider, a.log)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: err.Error()})
 
 		return
 	}
 
 	if !engine.IsAvailable() {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": fmt.Sprintf("provider %s is not available", provider)})
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{keyError: fmt.Sprintf("provider %s is not available", provider)})
 
 		return
 	}
 
 	status, health, ok := a.getServiceStatus(name)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "service not found: " + name})
+		writeJSON(w, http.StatusNotFound, map[string]string{keyError: "service not found: " + name})
 
 		return
 	}
 
 	logLines := a.collectServiceLogs(name)
 	if len(logLines) == 0 {
-		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "no logs available for service: " + name})
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{keyError: "no logs available for service: " + name})
 
 		return
 	}
@@ -125,7 +125,7 @@ func (a *apiHandler) handlePostDiagnose(w http.ResponseWriter, r *http.Request) 
 
 	response, err := engine.Ask(r.Context(), prompt)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("diagnosis failed: %v", err)})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{keyError: fmt.Sprintf("diagnosis failed: %v", err)})
 
 		return
 	}
@@ -137,14 +137,14 @@ func (a *apiHandler) handlePostDiagnose(w http.ResponseWriter, r *http.Request) 
 func (a *apiHandler) handlePostDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service name required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgServiceNameRequired})
 
 		return
 	}
 
 	var req diagnoseStartRequest
 	if err := decodeJSONBody(r, &req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: err.Error()})
 
 		return
 	}
@@ -153,27 +153,27 @@ func (a *apiHandler) handlePostDiagnoseStart(w http.ResponseWriter, r *http.Requ
 
 	engine, err := ai.NewEngine(provider, a.log)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: err.Error()})
 
 		return
 	}
 
 	if !engine.IsAvailable() {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": fmt.Sprintf("provider %s is not available", provider)})
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{keyError: fmt.Sprintf("provider %s is not available", provider)})
 
 		return
 	}
 
 	status, health, ok := a.getServiceStatus(name)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "service not found: " + name})
+		writeJSON(w, http.StatusNotFound, map[string]string{keyError: "service not found: " + name})
 
 		return
 	}
 
 	logLines := a.collectServiceLogs(name)
 	if len(logLines) == 0 {
-		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "no logs available for service: " + name})
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{keyError: "no logs available for service: " + name})
 
 		return
 	}
@@ -185,7 +185,7 @@ func (a *apiHandler) handlePostDiagnoseStart(w http.ResponseWriter, r *http.Requ
 
 	session, err := engine.StartSession(sessionCtx)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to start provider session: %v", err)})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{keyError: fmt.Sprintf("failed to start provider session: %v", err)})
 
 		return
 	}
@@ -200,9 +200,9 @@ func (a *apiHandler) handlePostDiagnoseStart(w http.ResponseWriter, r *http.Requ
 
 	requestID := normalizeRequestID(req.RequestID)
 	writeJSON(w, http.StatusAccepted, map[string]string{
-		"sessionId": s.id,
-		"requestId": requestID,
-		"provider":  string(provider),
+		keySessionID: s.id,
+		keyRequestID: requestID,
+		keyProvider:  string(provider),
 	})
 
 	prompt := buildDiagnosePrompt(name, status, health, logLines)
@@ -212,48 +212,48 @@ func (a *apiHandler) handlePostDiagnoseStart(w http.ResponseWriter, r *http.Requ
 func (a *apiHandler) handlePostDiagnoseMessage(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service name required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgServiceNameRequired})
 
 		return
 	}
 
 	var req diagnoseMessageRequest
 	if err := decodeJSONBody(r, &req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: err.Error()})
 
 		return
 	}
 
 	if strings.TrimSpace(req.SessionID) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "sessionId is required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "sessionId is required"})
 
 		return
 	}
 
 	if strings.TrimSpace(req.Prompt) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "prompt is required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "prompt is required"})
 
 		return
 	}
 
 	s, ok := a.getDiagnoseSession(req.SessionID)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "diagnose session not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{keyError: errMsgDiagnoseSessionNotFound})
 
 		return
 	}
 
 	if s.service != name {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session/service mismatch"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgSessionServiceMismatch})
 
 		return
 	}
 
 	requestID := normalizeRequestID(req.RequestID)
 	writeJSON(w, http.StatusAccepted, map[string]string{
-		"sessionId": s.id,
-		"requestId": requestID,
-		"provider":  string(s.provider),
+		keySessionID: s.id,
+		keyRequestID: requestID,
+		keyProvider:  string(s.provider),
 	})
 
 	go a.runDiagnoseTurn(s, requestID, buildFollowUpPrompt(req.Prompt))
@@ -282,33 +282,33 @@ func buildFollowUpPrompt(userPrompt string) string {
 func (a *apiHandler) handlePostDiagnoseInterrupt(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service name required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgServiceNameRequired})
 
 		return
 	}
 
 	var req diagnoseInterruptRequest
 	if err := decodeJSONBody(r, &req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: err.Error()})
 
 		return
 	}
 
 	if strings.TrimSpace(req.SessionID) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "sessionId is required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "sessionId is required"})
 
 		return
 	}
 
 	s, ok := a.getDiagnoseSession(req.SessionID)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "diagnose session not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{keyError: errMsgDiagnoseSessionNotFound})
 
 		return
 	}
 
 	if s.service != name {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session/service mismatch"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgSessionServiceMismatch})
 
 		return
 	}
@@ -316,23 +316,23 @@ func (a *apiHandler) handlePostDiagnoseInterrupt(w http.ResponseWriter, r *http.
 	s.setInterrupted(true)
 
 	if err := s.session.Interrupt(r.Context()); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("interrupt failed: %v", err)})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{keyError: fmt.Sprintf("interrupt failed: %v", err)})
 
 		return
 	}
 
 	requestID := normalizeRequestID(req.RequestID)
 	a.broadcastDiagnoseEvent("diagnose_interrupted", map[string]any{
-		"sessionId": s.id,
-		"requestId": requestID,
-		"service":   s.service,
-		"provider":  s.provider,
+		keySessionID: s.id,
+		keyRequestID: requestID,
+		keyService:   s.service,
+		keyProvider:  s.provider,
 	})
 
 	writeJSON(w, http.StatusAccepted, map[string]string{
-		"status":    "interrupted",
-		"sessionId": s.id,
-		"requestId": requestID,
+		keyStatus:    "interrupted",
+		keySessionID: s.id,
+		keyRequestID: requestID,
 	})
 }
 
@@ -341,14 +341,14 @@ func (a *apiHandler) handleDeleteDiagnoseSession(w http.ResponseWriter, r *http.
 	sessionID := r.PathValue("session")
 
 	if name == "" || sessionID == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service and session are required"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "service and session are required"})
 
 		return
 	}
 
 	s, ok := a.deleteDiagnoseSession(sessionID)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "diagnose session not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{keyError: errMsgDiagnoseSessionNotFound})
 
 		return
 	}
@@ -356,24 +356,24 @@ func (a *apiHandler) handleDeleteDiagnoseSession(w http.ResponseWriter, r *http.
 	if s.service != name {
 		_ = s.session.Close()
 
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session/service mismatch"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: errMsgSessionServiceMismatch})
 
 		return
 	}
 
 	if err := s.session.Close(); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to close session: %v", err)})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{keyError: fmt.Sprintf("failed to close session: %v", err)})
 
 		return
 	}
 
 	a.broadcastDiagnoseEvent("diagnose_session_closed", map[string]any{
-		"sessionId": s.id,
-		"service":   s.service,
-		"provider":  s.provider,
+		keySessionID: s.id,
+		keyService:   s.service,
+		keyProvider:  s.provider,
 	})
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "closed", "sessionId": s.id})
+	writeJSON(w, http.StatusOK, map[string]string{keyStatus: "closed", keySessionID: s.id})
 }
 
 func (a *apiHandler) runDiagnoseTurn(s *diagnoseSession, requestID, prompt string) {
@@ -382,11 +382,11 @@ func (a *apiHandler) runDiagnoseTurn(s *diagnoseSession, requestID, prompt strin
 
 	s.setInterrupted(false)
 	a.broadcastDiagnoseEvent("diagnose_started", map[string]any{
-		"sessionId": s.id,
-		"requestId": requestID,
-		"service":   s.service,
-		"provider":  s.provider,
-		"ts":        time.Now().UTC(),
+		keySessionID: s.id,
+		keyRequestID: requestID,
+		keyService:   s.service,
+		keyProvider:  s.provider,
+		"ts":         time.Now().UTC(),
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), diagnoseTurnTimeout)
@@ -394,14 +394,14 @@ func (a *apiHandler) runDiagnoseTurn(s *diagnoseSession, requestID, prompt strin
 
 	response, err := s.session.AskStream(ctx, prompt, func(chunk ai.StreamChunk) {
 		a.broadcastDiagnoseEvent("diagnose_stream", map[string]any{
-			"sessionId": s.id,
-			"requestId": requestID,
-			"service":   s.service,
-			"provider":  s.provider,
-			"kind":      chunk.Kind,
-			"text":      chunk.Text,
-			"eventType": chunk.EventType,
-			"seq":       chunk.Seq,
+			keySessionID: s.id,
+			keyRequestID: requestID,
+			keyService:   s.service,
+			keyProvider:  s.provider,
+			"kind":       chunk.Kind,
+			keyText:      chunk.Text,
+			"eventType":  chunk.EventType,
+			"seq":        chunk.Seq,
 		})
 	})
 	if err != nil {
@@ -417,18 +417,18 @@ func (a *apiHandler) runDiagnoseTurn(s *diagnoseSession, requestID, prompt strin
 		}
 
 		a.log.WithError(err).WithFields(map[string]any{
-			"service":    s.service,
+			keyService:   s.service,
 			"session_id": s.id,
-			"provider":   s.provider,
+			keyProvider:  s.provider,
 			"debug":      debugInfo,
 		}).Warn("diagnose stream failed")
 
 		a.broadcastDiagnoseEvent("diagnose_error", map[string]any{
-			"sessionId": s.id,
-			"requestId": requestID,
-			"service":   s.service,
-			"provider":  s.provider,
-			"error":     err.Error(),
+			keySessionID: s.id,
+			keyRequestID: requestID,
+			keyService:   s.service,
+			keyProvider:  s.provider,
+			keyError:     err.Error(),
 		})
 
 		return
@@ -436,12 +436,12 @@ func (a *apiHandler) runDiagnoseTurn(s *diagnoseSession, requestID, prompt strin
 
 	diagnosis := diagnostic.ParseDiagnosisResponse(response)
 	a.broadcastDiagnoseEvent("diagnose_result", map[string]any{
-		"sessionId": s.id,
-		"requestId": requestID,
-		"service":   s.service,
-		"provider":  s.provider,
-		"rawText":   response,
-		"diagnosis": diagnosis,
+		keySessionID: s.id,
+		keyRequestID: requestID,
+		keyService:   s.service,
+		keyProvider:  s.provider,
+		"rawText":    response,
+		"diagnosis":  diagnosis,
 	})
 }
 

--- a/pkg/cc/api_redis.go
+++ b/pkg/cc/api_redis.go
@@ -146,8 +146,8 @@ func (a *apiHandler) handlePostRedisKey(w http.ResponseWriter, r *http.Request) 
 		var conflict *redisConflictError
 		if errors.As(err, &conflict) {
 			writeJSON(w, http.StatusConflict, map[string]any{
-				"error": "key already exists",
-				"code":  "already_exists",
+				keyError: "key already exists",
+				"code":   "already_exists",
 			})
 
 			return
@@ -187,7 +187,7 @@ func (a *apiHandler) handlePutRedisKey(w http.ResponseWriter, r *http.Request) {
 		var conflict *redisConflictError
 		if errors.As(err, &conflict) {
 			payload := map[string]any{
-				"error":          "key changed since it was loaded",
+				keyError:         "key changed since it was loaded",
 				"code":           "conflict",
 				"reloadRequired": true,
 			}
@@ -339,7 +339,7 @@ func validateRedisWriteBody(req redisWriteRequest) error {
 
 func writeRedisError(w http.ResponseWriter, status int, message string, err error) {
 	payload := map[string]any{
-		"error": message,
+		keyError: message,
 	}
 
 	if err != nil {

--- a/pkg/cc/api_stack.go
+++ b/pkg/cc/api_stack.go
@@ -36,7 +36,7 @@ func (a *apiHandler) handlePostStackUp(w http.ResponseWriter, _ *http.Request) {
 		a.stack.mu.Unlock()
 
 		writeJSON(w, http.StatusConflict, map[string]string{
-			"error": "stack is currently " + current,
+			keyError: "stack is currently " + current,
 		})
 
 		return
@@ -73,8 +73,8 @@ func (a *apiHandler) handlePostStackUp(w http.ResponseWriter, _ *http.Request) {
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_progress", map[string]string{
-				"phase":   phase,
-				"message": message,
+				keyPhase:   phase,
+				keyMessage: message,
 			})
 		}
 
@@ -94,7 +94,7 @@ func (a *apiHandler) handlePostStackUp(w http.ResponseWriter, _ *http.Request) {
 		if err != nil {
 			a.log.WithError(err).Error("stack boot failed")
 			a.sseHub.Broadcast("stack_error", map[string]string{
-				"error": err.Error(),
+				keyError: err.Error(),
 			})
 
 			return
@@ -105,7 +105,7 @@ func (a *apiHandler) handlePostStackUp(w http.ResponseWriter, _ *http.Request) {
 	}()
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": stackStatusStarting,
+		keyStatus: stackStatusStarting,
 	})
 }
 
@@ -121,7 +121,7 @@ func (a *apiHandler) handlePostStackDown(
 		a.stack.mu.Unlock()
 
 		writeJSON(w, http.StatusConflict, map[string]string{
-			"error": "stack is currently " + current,
+			keyError: "stack is currently " + current,
 		})
 
 		return
@@ -148,8 +148,8 @@ func (a *apiHandler) handlePostStackDown(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_progress", map[string]string{
-				"phase":   phase,
-				"message": message,
+				keyPhase:   phase,
+				keyMessage: message,
 			})
 		}
 
@@ -167,7 +167,7 @@ func (a *apiHandler) handlePostStackDown(
 		if err != nil {
 			a.log.WithError(err).Error("stack teardown failed")
 			a.sseHub.Broadcast("stack_error", map[string]string{
-				"error": err.Error(),
+				keyError: err.Error(),
 			})
 
 			return
@@ -178,7 +178,7 @@ func (a *apiHandler) handlePostStackDown(
 	}()
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": stackStatusStopping,
+		keyStatus: stackStatusStopping,
 	})
 }
 
@@ -194,7 +194,7 @@ func (a *apiHandler) handlePostStackRestart(
 		a.stack.mu.Unlock()
 
 		writeJSON(w, http.StatusConflict, map[string]string{
-			"error": "stack is currently " + current,
+			keyError: "stack is currently " + current,
 		})
 
 		return
@@ -216,8 +216,8 @@ func (a *apiHandler) handlePostStackRestart(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_progress", map[string]string{
-				"phase":   phase,
-				"message": message,
+				keyPhase:   phase,
+				keyMessage: message,
 			})
 		}
 
@@ -236,7 +236,7 @@ func (a *apiHandler) handlePostStackRestart(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_error", map[string]string{
-				"error": err.Error(),
+				keyError: err.Error(),
 			})
 
 			return
@@ -274,7 +274,7 @@ func (a *apiHandler) handlePostStackRestart(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_error", map[string]string{
-				"error": err.Error(),
+				keyError: err.Error(),
 			})
 
 			return
@@ -289,7 +289,7 @@ func (a *apiHandler) handlePostStackRestart(
 	}()
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": stackStatusStopping,
+		keyStatus: stackStatusStopping,
 	})
 }
 
@@ -360,7 +360,7 @@ func (a *apiHandler) handlePostStackCancel(
 		a.stack.mu.Unlock()
 
 		writeJSON(w, http.StatusConflict, map[string]string{
-			"error": "stack is not currently starting",
+			keyError: "stack is not currently starting",
 		})
 
 		return
@@ -393,8 +393,8 @@ func (a *apiHandler) handlePostStackCancel(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_progress", map[string]string{
-				"phase":   phase,
-				"message": message,
+				keyPhase:   phase,
+				keyMessage: message,
 			})
 		}
 
@@ -407,7 +407,7 @@ func (a *apiHandler) handlePostStackCancel(
 			a.stack.mu.Unlock()
 
 			a.sseHub.Broadcast("stack_error", map[string]string{
-				"error": err.Error(),
+				keyError: err.Error(),
 			})
 
 			return
@@ -423,6 +423,6 @@ func (a *apiHandler) handlePostStackCancel(
 	}()
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": stackStatusStopping,
+		keyStatus: stackStatusStopping,
 	})
 }

--- a/pkg/cc/backend_lab.go
+++ b/pkg/cc/backend_lab.go
@@ -179,7 +179,7 @@ func (b *labBackend) RebuildService(ctx context.Context, name string) error {
 // LogSource returns how to stream logs for a given service.
 func (b *labBackend) LogSource(name string) LogSourceInfo {
 	if container, ok := dockerContainerNames[name]; ok {
-		return LogSourceInfo{Type: "docker", Container: container}
+		return LogSourceInfo{Type: cmdDocker, Container: container}
 	}
 
 	return LogSourceInfo{Type: "file", Path: b.orch.LogFilePath(name)}

--- a/pkg/cc/backend_xatu.go
+++ b/pkg/cc/backend_xatu.go
@@ -212,12 +212,12 @@ func (b *xatuBackend) LogSource(name string) LogSourceInfo {
 	if err == nil {
 		for _, svc := range statuses {
 			if svc.Service == name && svc.Name != "" {
-				return LogSourceInfo{Type: "docker", Container: svc.Name}
+				return LogSourceInfo{Type: cmdDocker, Container: svc.Name}
 			}
 		}
 	}
 
-	return LogSourceInfo{Type: "docker", Container: name}
+	return LogSourceInfo{Type: cmdDocker, Container: name}
 }
 
 // LogFilePath returns empty — Xatu uses docker logs, not file-based logs.

--- a/pkg/cc/redis_admin.go
+++ b/pkg/cc/redis_admin.go
@@ -44,7 +44,7 @@ func (e *redisConflictError) Error() string {
 
 // redisEncodedValue safely represents possibly-binary values.
 type redisEncodedValue struct {
-	Mode   string `json:"mode"` // "text" | "base64"
+	Mode   string `json:"mode"` // keyText | keyBase64
 	Text   string `json:"text,omitempty"`
 	Base64 string `json:"base64,omitempty"`
 }
@@ -499,7 +499,7 @@ func validateWriteRequest(req redisWriteRequest, isCreate bool) error {
 		return fmt.Errorf("unsupported key type: %s", req.Type)
 	}
 
-	if req.TTLMode == "set" && req.TTLSeconds <= 0 {
+	if req.TTLMode == redisTypeSet && req.TTLSeconds <= 0 {
 		return errors.New("ttlSeconds must be greater than 0 when ttlMode is set")
 	}
 
@@ -798,22 +798,22 @@ func readSetMembers(
 func encodeValue(value string) redisEncodedValue {
 	if utf8.ValidString(value) {
 		return redisEncodedValue{
-			Mode: "text",
+			Mode: keyText,
 			Text: value,
 		}
 	}
 
 	return redisEncodedValue{
-		Mode:   "base64",
+		Mode:   keyBase64,
 		Base64: base64.StdEncoding.EncodeToString([]byte(value)),
 	}
 }
 
 func decodeValue(value redisEncodedValue) (string, error) {
 	switch value.Mode {
-	case "", "text":
+	case "", keyText:
 		return value.Text, nil
-	case "base64":
+	case keyBase64:
 		data, err := base64.StdEncoding.DecodeString(value.Base64)
 		if err != nil {
 			return "", fmt.Errorf("invalid base64 value: %w", err)
@@ -911,7 +911,7 @@ func buildVersionToken(detail redisKeyDetailResponse) string {
 }
 
 func encodedSortValue(value redisEncodedValue) string {
-	if value.Mode == "base64" {
+	if value.Mode == keyBase64 {
 		return "b64:" + value.Base64
 	}
 

--- a/pkg/cc/redis_admin_test.go
+++ b/pkg/cc/redis_admin_test.go
@@ -2,6 +2,11 @@ package cc
 
 import "testing"
 
+const (
+	testKeyCBTExternal123 = "cbt:external:123"
+	testPrefixCBT         = "cbt:"
+)
+
 func TestSplitKeyByPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -16,8 +21,8 @@ func TestSplitKeyByPrefix(t *testing.T) {
 		{
 			name:         "root branch",
 			prefix:       "",
-			key:          "cbt:external:123",
-			wantBranch:   "cbt:",
+			key:          testKeyCBTExternal123,
+			wantBranch:   testPrefixCBT,
 			wantAccepted: true,
 		},
 		{
@@ -29,21 +34,21 @@ func TestSplitKeyByPrefix(t *testing.T) {
 		},
 		{
 			name:         "nested branch",
-			prefix:       "cbt:",
-			key:          "cbt:external:123",
+			prefix:       testPrefixCBT,
+			key:          testKeyCBTExternal123,
 			wantBranch:   "cbt:external:",
 			wantAccepted: true,
 		},
 		{
 			name:         "nested leaf",
 			prefix:       "cbt:external:",
-			key:          "cbt:external:123",
-			wantLeaf:     "cbt:external:123",
+			key:          testKeyCBTExternal123,
+			wantLeaf:     testKeyCBTExternal123,
 			wantAccepted: true,
 		},
 		{
 			name:         "non matching prefix",
-			prefix:       "cbt:",
+			prefix:       testPrefixCBT,
 			key:          "lab:foo",
 			wantAccepted: false,
 		},
@@ -73,20 +78,20 @@ func TestBuildVersionTokenSetOrderInsensitive(t *testing.T) {
 	t.Parallel()
 
 	base := redisKeyDetailResponse{
-		Type:  "set",
+		Type:  redisTypeSet,
 		TTLMS: 1234,
 		SetMembers: []redisEncodedValue{
-			{Mode: "text", Text: "a"},
-			{Mode: "text", Text: "b"},
+			{Mode: keyText, Text: "a"},
+			{Mode: keyText, Text: "b"},
 		},
 	}
 
 	reordered := redisKeyDetailResponse{
-		Type:  "set",
+		Type:  redisTypeSet,
 		TTLMS: 1234,
 		SetMembers: []redisEncodedValue{
-			{Mode: "text", Text: "b"},
-			{Mode: "text", Text: "a"},
+			{Mode: keyText, Text: "b"},
+			{Mode: keyText, Text: "a"},
 		},
 	}
 
@@ -102,8 +107,8 @@ func TestBuildVersionTokenListOrderSensitive(t *testing.T) {
 		Type:  "list",
 		TTLMS: 1,
 		ListItems: []redisEncodedValue{
-			{Mode: "text", Text: "a"},
-			{Mode: "text", Text: "b"},
+			{Mode: keyText, Text: "a"},
+			{Mode: keyText, Text: "b"},
 		},
 	}
 
@@ -111,8 +116,8 @@ func TestBuildVersionTokenListOrderSensitive(t *testing.T) {
 		Type:  "list",
 		TTLMS: 1,
 		ListItems: []redisEncodedValue{
-			{Mode: "text", Text: "b"},
-			{Mode: "text", Text: "a"},
+			{Mode: keyText, Text: "b"},
+			{Mode: keyText, Text: "a"},
 		},
 	}
 

--- a/pkg/cc/server.go
+++ b/pkg/cc/server.go
@@ -216,7 +216,7 @@ func (s *Server) stackHandler(
 
 		if !ok {
 			writeJSON(w, http.StatusNotFound, map[string]string{
-				"error": "unknown stack: " + name,
+				keyError: "unknown stack: " + name,
 			})
 
 			return

--- a/pkg/cc/stack_backend.go
+++ b/pkg/cc/stack_backend.go
@@ -22,11 +22,11 @@ type ProgressFunc func(phase string, message string)
 
 // LogSourceInfo describes how to stream logs for a service.
 type LogSourceInfo struct {
-	// Type is "file" or "docker".
+	// Type is "file" or cmdDocker.
 	Type string
 	// Path is the log file path (when Type == "file").
 	Path string
-	// Container is the Docker container name (when Type == "docker").
+	// Container is the Docker container name (when Type == cmdDocker).
 	Container string
 }
 

--- a/pkg/cc/stack_context.go
+++ b/pkg/cc/stack_context.go
@@ -193,17 +193,17 @@ func (sc *stackContext) startLogStreaming(ctx context.Context) {
 		src := sc.backend.LogSource(svc.Name)
 
 		switch src.Type {
-		case "docker":
+		case cmdDocker:
 			if err := sc.logs.StartDocker(svc.Name, src.Container); err != nil {
 				sc.log.WithError(err).WithField(
-					"service", svc.Name,
+					keyService, svc.Name,
 				).Warn("Failed to start Docker log streaming")
 			}
 		case "file":
 			if src.Path != "" {
 				if err := sc.logs.Start(svc.Name, src.Path); err != nil {
 					sc.log.WithError(err).WithField(
-						"service", svc.Name,
+						keyService, svc.Name,
 					).Warn("Failed to start log streaming")
 				}
 			}

--- a/pkg/commands/lab_release.go
+++ b/pkg/commands/lab_release.go
@@ -17,6 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version bump types and release action values.
+const (
+	bumpPatch  = "patch"
+	bumpMinor  = "minor"
+	bumpMajor  = "major"
+	actionSkip = "skip"
+)
+
 // NewLabReleaseCommand creates the lab release command.
 func NewLabReleaseCommand(log logrus.FieldLogger, _ string) *cobra.Command {
 	var (
@@ -317,7 +325,7 @@ func promptMissingDependencies(
 		{
 			Label:       fmt.Sprintf("No, use existing %s %s", missingDeps[0], depVersion),
 			Description: fmt.Sprintf("%s will import the current %s version", project, missingDeps[0]),
-			Value:       "skip",
+			Value:       actionSkip,
 		},
 		{
 			Label:       fmt.Sprintf("Yes, release %s first", missingDeps[0]),
@@ -717,14 +725,14 @@ func selectProjectsInteractive(projectInfos []release.ProjectInfo) ([]string, er
 
 func selectBumpType(project, currentVersion string) (release.BumpType, error) {
 	options := []ui.SelectOption{
-		{Label: "patch", Description: "Bug fixes (0.0.X)", Value: "patch"},
-		{Label: "minor", Description: "New features (0.X.0)", Value: "minor"},
-		{Label: "major", Description: "Breaking changes (X.0.0)", Value: "major"},
+		{Label: bumpPatch, Description: "Bug fixes (0.0.X)", Value: bumpPatch},
+		{Label: bumpMinor, Description: "New features (0.X.0)", Value: bumpMinor},
+		{Label: bumpMajor, Description: "Breaking changes (X.0.0)", Value: bumpMajor},
 	}
 
 	title := fmt.Sprintf("Version bump for %s (current: %s)", project, currentVersion)
 
-	selected, err := ui.SelectWithDefault(title, options, "patch")
+	selected, err := ui.SelectWithDefault(title, options, bumpPatch)
 	if err != nil {
 		return "", fmt.Errorf("bump selection cancelled: %w", err)
 	}
@@ -754,11 +762,11 @@ func handleSemverRelease(
 
 	if bumpFlag != "" {
 		switch bumpFlag {
-		case "patch":
+		case bumpPatch:
 			bumpType = release.BumpPatch
-		case "minor":
+		case bumpMinor:
 			bumpType = release.BumpMinor
-		case "major":
+		case bumpMajor:
 			bumpType = release.BumpMajor
 		default:
 			return nil, fmt.Errorf("invalid bump type: %s (valid: patch, minor, major)", bumpFlag)
@@ -766,22 +774,22 @@ func handleSemverRelease(
 	} else {
 		// Interactive bump selection
 		options := []ui.SelectOption{
-			{Label: "patch", Description: "Bug fixes (0.0.X)", Value: "patch"},
-			{Label: "minor", Description: "New features (0.X.0)", Value: "minor"},
-			{Label: "major", Description: "Breaking changes (X.0.0)", Value: "major"},
+			{Label: bumpPatch, Description: "Bug fixes (0.0.X)", Value: bumpPatch},
+			{Label: bumpMinor, Description: "New features (0.X.0)", Value: bumpMinor},
+			{Label: bumpMajor, Description: "Breaking changes (X.0.0)", Value: bumpMajor},
 		}
 
-		selected, err := ui.SelectWithDefault("Select version bump type", options, "patch")
+		selected, err := ui.SelectWithDefault("Select version bump type", options, bumpPatch)
 		if err != nil {
 			return nil, fmt.Errorf("bump selection cancelled: %w", err)
 		}
 
 		switch selected {
-		case "patch":
+		case bumpPatch:
 			bumpType = release.BumpPatch
-		case "minor":
+		case bumpMinor:
 			bumpType = release.BumpMinor
-		case "major":
+		case bumpMajor:
 			bumpType = release.BumpMajor
 		}
 	}
@@ -1056,7 +1064,7 @@ func promptDependencyConfirmation(
 				{
 					Label:       fmt.Sprintf("No, use existing %s %s", dep, depVersion),
 					Description: fmt.Sprintf("%s will import the current %s version", project, dep),
-					Value:       "skip",
+					Value:       actionSkip,
 				},
 			}
 
@@ -1068,7 +1076,7 @@ func promptDependencyConfirmation(
 				return nil, selectErr
 			}
 
-			if selected == "skip" {
+			if selected == actionSkip {
 				projectsToRemove[dep] = true
 			}
 		}

--- a/pkg/commands/lab_xatu_cbt_generate_transformation.go
+++ b/pkg/commands/lab_xatu_cbt_generate_transformation.go
@@ -17,6 +17,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// defaultTransformationDuration is the default duration for transformation tests.
+const defaultTransformationDuration = "5m"
+
 // generateTransformationTestOptions holds all options for the generate-transformation-test command.
 type generateTransformationTestOptions struct {
 	model           string
@@ -184,7 +187,7 @@ func runGenerateTransformationTest(
 		}
 
 		if duration == "" {
-			duration = "5m" // Default duration in non-interactive mode
+			duration = defaultTransformationDuration // Default duration in non-interactive mode
 		}
 	}
 
@@ -258,7 +261,7 @@ func runGenerateTransformationTest(
 			{Label: "10m", Description: "recommended", Value: "10m"},
 			{Label: "30s", Description: "minimal test", Value: "30s"},
 			{Label: "1m", Description: "quick test", Value: "1m"},
-			{Label: "5m", Description: "", Value: "5m"},
+			{Label: defaultTransformationDuration, Description: "", Value: defaultTransformationDuration},
 			{Label: "30m", Description: "", Value: "30m"},
 			{Label: "1h", Description: "large dataset", Value: "1h"},
 			{Label: "6h", Description: "", Value: "6h"},
@@ -1039,7 +1042,7 @@ func runBatchGenerateTransformationTest(
 
 	// Set defaults for batch mode
 	if opts.duration == "" {
-		opts.duration = "5m"
+		opts.duration = defaultTransformationDuration
 	}
 
 	// Force non-interactive mode for batch

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,6 +79,60 @@ type ClickHouseClusterConfig struct {
 	ExternalDatabase string `yaml:"externalDatabase,omitempty"`
 	ExternalUsername string `yaml:"externalUsername,omitempty"`
 	ExternalPassword string `yaml:"externalPassword,omitempty"`
+}
+
+// ExternalURLWithCredentials returns ExternalURL with ExternalUsername and
+// ExternalPassword injected into the URL's userinfo. Consumers such as
+// xatu-cbt read credentials only from the URL, so the separately-configured
+// fields must be embedded before the URL is handed off. Credentials already
+// present in ExternalURL are preserved unless overridden by the explicit fields.
+func (c ClickHouseClusterConfig) ExternalURLWithCredentials() (string, error) {
+	if c.ExternalURL == "" {
+		return "", nil
+	}
+
+	if c.ExternalUsername == "" && c.ExternalPassword == "" {
+		return c.ExternalURL, nil
+	}
+
+	parsed, err := url.Parse(c.ExternalURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse external ClickHouse URL: %w", err)
+	}
+
+	// Seed from any credentials already embedded in the URL, then let the
+	// explicit fields take precedence.
+	username := ""
+	password := ""
+
+	if parsed.User != nil {
+		username = parsed.User.Username()
+		password, _ = parsed.User.Password()
+	}
+
+	if c.ExternalUsername != "" {
+		username = c.ExternalUsername
+	}
+
+	if c.ExternalPassword != "" {
+		password = c.ExternalPassword
+	}
+
+	// A password with no username is unusable by ClickHouse (it would produce a
+	// ":password@host" userinfo). Fall back to the "default" user, which is what
+	// a password-only configuration implies.
+	if password != "" && username == "" {
+		username = "default"
+	}
+
+	switch {
+	case password != "":
+		parsed.User = url.UserPassword(username, password)
+	case username != "":
+		parsed.User = url.User(username)
+	}
+
+	return parsed.String(), nil
 }
 
 // RedisConfig contains Redis configuration.
@@ -373,7 +428,7 @@ func DefaultLab() *LabConfig {
 			ClickHouse: ClickHouseConfig{
 				Xatu: ClickHouseClusterConfig{
 					Mode:             constants.InfraModeExternal,
-					ExternalURL:      "http://chendpoint-xatu-clickhouse.analytics.production.ethpandaops:9000",
+					ExternalURL:      "http://chendpoint-clickhouse-raw.analytics.production.ethpandaops:9000",
 					ExternalDatabase: "default",
 				},
 				CBT: ClickHouseClusterConfig{Mode: constants.InfraModeLocal},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testHost = "http://host:9000"
+	testUser = "readonly"
+	testPass = "s3cr3t"
+)
+
 func TestExternalURLWithCredentials(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -21,15 +27,15 @@ func TestExternalURLWithCredentials(t *testing.T) {
 		},
 		{
 			name: "no credentials leaves URL unchanged",
-			cfg:  ClickHouseClusterConfig{ExternalURL: "http://host:9000"},
-			want: "http://host:9000",
+			cfg:  ClickHouseClusterConfig{ExternalURL: testHost},
+			want: testHost,
 		},
 		{
 			name: "username and password are embedded",
 			cfg: ClickHouseClusterConfig{
-				ExternalURL:      "http://host:9000",
-				ExternalUsername: "readonly",
-				ExternalPassword: "s3cr3t",
+				ExternalURL:      testHost,
+				ExternalUsername: testUser,
+				ExternalPassword: testPass,
 			},
 			want: "http://readonly:s3cr3t@host:9000",
 		},
@@ -53,16 +59,16 @@ func TestExternalURLWithCredentials(t *testing.T) {
 		{
 			name: "password-only falls back to default user",
 			cfg: ClickHouseClusterConfig{
-				ExternalURL:      "http://host:9000",
-				ExternalPassword: "s3cr3t",
+				ExternalURL:      testHost,
+				ExternalPassword: testPass,
 			},
 			want: "http://default:s3cr3t@host:9000",
 		},
 		{
 			name: "special characters in password are percent-encoded",
 			cfg: ClickHouseClusterConfig{
-				ExternalURL:      "http://host:9000",
-				ExternalUsername: "readonly",
+				ExternalURL:      testHost,
+				ExternalUsername: testUser,
 				ExternalPassword: "p@ss:w/rd?",
 			},
 			want: "http://readonly:p%40ss%3Aw%2Frd%3F@host:9000",
@@ -71,8 +77,8 @@ func TestExternalURLWithCredentials(t *testing.T) {
 			name: "https scheme is preserved",
 			cfg: ClickHouseClusterConfig{
 				ExternalURL:      "https://host:8443",
-				ExternalUsername: "readonly",
-				ExternalPassword: "s3cr3t",
+				ExternalUsername: testUser,
+				ExternalPassword: testPass,
 			},
 			want: "https://readonly:s3cr3t@host:8443",
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalURLWithCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ClickHouseClusterConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "empty URL returns empty",
+			cfg:  ClickHouseClusterConfig{},
+			want: "",
+		},
+		{
+			name: "no credentials leaves URL unchanged",
+			cfg:  ClickHouseClusterConfig{ExternalURL: "http://host:9000"},
+			want: "http://host:9000",
+		},
+		{
+			name: "username and password are embedded",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "http://host:9000",
+				ExternalUsername: "readonly",
+				ExternalPassword: "s3cr3t",
+			},
+			want: "http://readonly:s3cr3t@host:9000",
+		},
+		{
+			name: "explicit fields override credentials already in URL",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "http://olduser:oldpass@host:9000",
+				ExternalUsername: "newuser",
+				ExternalPassword: "newpass",
+			},
+			want: "http://newuser:newpass@host:9000",
+		},
+		{
+			name: "username override preserves password already in URL",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "http://olduser:oldpass@host:9000",
+				ExternalUsername: "newuser",
+			},
+			want: "http://newuser:oldpass@host:9000",
+		},
+		{
+			name: "password-only falls back to default user",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "http://host:9000",
+				ExternalPassword: "s3cr3t",
+			},
+			want: "http://default:s3cr3t@host:9000",
+		},
+		{
+			name: "special characters in password are percent-encoded",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "http://host:9000",
+				ExternalUsername: "readonly",
+				ExternalPassword: "p@ss:w/rd?",
+			},
+			want: "http://readonly:p%40ss%3Aw%2Frd%3F@host:9000",
+		},
+		{
+			name: "https scheme is preserved",
+			cfg: ClickHouseClusterConfig{
+				ExternalURL:      "https://host:8443",
+				ExternalUsername: "readonly",
+				ExternalPassword: "s3cr3t",
+			},
+			want: "https://readonly:s3cr3t@host:8443",
+		},
+		{
+			name:    "invalid URL returns error",
+			cfg:     ClickHouseClusterConfig{ExternalURL: "http://[::1", ExternalUsername: "u"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.cfg.ExternalURLWithCredentials()
+
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/configgen/generator.go
+++ b/pkg/configgen/generator.go
@@ -31,6 +31,19 @@ const (
 	cbtAPIMetricsPortBase = 9200
 )
 
+const (
+	keyPort                      = "Port"
+	keyEnv                       = "env"
+	keyModels                    = "models"
+	keyNetwork                   = "NETWORK"
+	keyOverrides                 = "overrides"
+	networkMainnet               = "mainnet"
+	envExternalModelMinTimestamp = "EXTERNAL_MODEL_MIN_TIMESTAMP"
+	envExternalModelMinBlock     = "EXTERNAL_MODEL_MIN_BLOCK"
+	envModelsScriptsPath         = "MODELS_SCRIPTS_PATH"
+	modelsScriptsPath            = "../xatu-cbt/models/scripts"
+)
+
 // Generator generates service configuration files.
 type Generator struct {
 	log logrus.FieldLogger
@@ -167,7 +180,7 @@ func (g *Generator) GenerateCBTAPIConfig(network string) (string, error) {
 
 	data := map[string]any{
 		"Network":     network,
-		"Port":        port,
+		keyPort:       port,
 		"MetricsPort": metricsPort,
 	}
 
@@ -212,7 +225,7 @@ func (g *Generator) GenerateLabBackendConfig(
 	for _, net := range g.cfg.Networks {
 		entry := map[string]any{
 			"Name":    net.Name,
-			"Port":    g.cfg.GetCBTAPIPort(net.Name),
+			keyPort:   g.cfg.GetCBTAPIPort(net.Name),
 			"Enabled": net.Enabled,
 		}
 
@@ -231,7 +244,7 @@ func (g *Generator) GenerateLabBackendConfig(
 
 	data := map[string]any{
 		"Networks":     networks,
-		"Port":         g.cfg.Ports.LabBackend,
+		keyPort:        g.cfg.Ports.LabBackend,
 		"FrontendPort": g.cfg.Ports.LabFrontend,
 	}
 
@@ -256,22 +269,22 @@ func (g *Generator) generateAutoDefaults(network string) (map[string]any, error)
 
 	// Set sane default for mainnet
 	externalModelMinBlock := 0
-	if network == "mainnet" {
+	if network == networkMainnet {
 		externalModelMinBlock = 23800000
 	}
 
 	// Build models section with env
 	modelsSection := map[string]any{
-		"env": map[string]any{
-			"NETWORK":                      network,
-			"EXTERNAL_MODEL_MIN_TIMESTAMP": fmt.Sprintf("%d", externalModelMinTimestamp),
-			"EXTERNAL_MODEL_MIN_BLOCK":     fmt.Sprintf("%d", externalModelMinBlock),
-			"MODELS_SCRIPTS_PATH":          "../xatu-cbt/models/scripts",
+		keyEnv: map[string]any{
+			keyNetwork:                   network,
+			envExternalModelMinTimestamp: fmt.Sprintf("%d", externalModelMinTimestamp),
+			envExternalModelMinBlock:     fmt.Sprintf("%d", externalModelMinBlock),
+			envModelsScriptsPath:         modelsScriptsPath,
 		},
 	}
 
 	return map[string]any{
-		"models": modelsSection,
+		keyModels: modelsSection,
 	}, nil
 }
 
@@ -280,7 +293,7 @@ func (g *Generator) generateAutoDefaults(network string) (map[string]any, error)
 // not explicitly listed in overrides. This ensures the cbt binary receives
 // a fully-expanded config even in allowlist mode.
 func (g *Generator) expandDefaultEnabled(userOverrides map[string]any) {
-	models, ok := userOverrides["models"].(map[string]any)
+	models, ok := userOverrides[keyModels].(map[string]any)
 	if !ok {
 		return
 	}
@@ -315,10 +328,10 @@ func (g *Generator) expandDefaultEnabled(userOverrides map[string]any) {
 	}
 
 	// Get existing overrides map, or create one.
-	overrides, ok := models["overrides"].(map[string]any)
+	overrides, ok := models[keyOverrides].(map[string]any)
 	if !ok {
 		overrides = make(map[string]any, len(allModels))
-		models["overrides"] = overrides
+		models[keyOverrides] = overrides
 	}
 
 	// Inject enabled: false for all models not already listed.
@@ -387,7 +400,7 @@ func discoverAllModels(xatuCBTPath string) ([]string, error) {
 	models := make([]string, 0, 64)
 
 	// Discover external models (.sql files).
-	externalDir := filepath.Join(xatuCBTPath, "models", "external")
+	externalDir := filepath.Join(xatuCBTPath, keyModels, "external")
 
 	entries, err := os.ReadDir(externalDir)
 	if err != nil {
@@ -409,7 +422,7 @@ func discoverAllModels(xatuCBTPath string) ([]string, error) {
 	}
 
 	// Discover transformation models (.sql, .yml, .yaml files).
-	transformDir := filepath.Join(xatuCBTPath, "models", "transformations")
+	transformDir := filepath.Join(xatuCBTPath, keyModels, "transformations")
 
 	entries, err = os.ReadDir(transformDir)
 	if err != nil {

--- a/pkg/configgen/generator_test.go
+++ b/pkg/configgen/generator_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	fctBlock            = "fct_block"
+	fctBlockHead        = "fct_block_head"
+	fctAttestation      = "fct_attestation"
+	fctProposerSlashing = "fct_proposer_slashing"
+	fctBlockSummary     = "fct_block_summary"
+	fctSummary          = "fct_summary"
+)
+
 // setupFakeXatuCBTRepo creates a fake xatu-cbt repo directory structure
 // with the given external and transformation model names.
 func setupFakeXatuCBTRepo(
@@ -23,7 +32,7 @@ func setupFakeXatuCBTRepo(
 
 	repoDir := t.TempDir()
 
-	externalDir := filepath.Join(repoDir, "models", "external")
+	externalDir := filepath.Join(repoDir, keyModels, "external")
 	require.NoError(t, os.MkdirAll(externalDir, 0755))
 
 	for _, name := range external {
@@ -31,7 +40,7 @@ func setupFakeXatuCBTRepo(
 		require.NoError(t, os.WriteFile(path, []byte("SELECT 1"), 0600))
 	}
 
-	transformDir := filepath.Join(repoDir, "models", "transformations")
+	transformDir := filepath.Join(repoDir, keyModels, "transformations")
 	require.NoError(t, os.MkdirAll(transformDir, 0755))
 
 	for _, name := range transformations {
@@ -44,12 +53,12 @@ func setupFakeXatuCBTRepo(
 
 func TestGetLocallyEnabledTables(t *testing.T) {
 	allExternal := []string{
-		"fct_block",
-		"fct_block_head",
-		"fct_attestation",
-		"fct_proposer_slashing",
+		fctBlock,
+		fctBlockHead,
+		fctAttestation,
+		fctProposerSlashing,
 	}
-	allTransformations := []string{"fct_block_summary"}
+	allTransformations := []string{fctBlockSummary}
 
 	tests := []struct {
 		name            string
@@ -65,11 +74,11 @@ models:
   overrides: {}
 `,
 			expectedTables: []string{
-				"fct_attestation",
-				"fct_block",
-				"fct_block_head",
-				"fct_block_summary",
-				"fct_proposer_slashing",
+				fctAttestation,
+				fctBlock,
+				fctBlockHead,
+				fctBlockSummary,
+				fctProposerSlashing,
 			},
 		},
 		{
@@ -83,9 +92,9 @@ models:
       enabled: false
 `,
 			expectedTables: []string{
-				"fct_block",
-				"fct_block_head",
-				"fct_block_summary",
+				fctBlock,
+				fctBlockHead,
+				fctBlockSummary,
 			},
 		},
 		{
@@ -110,11 +119,11 @@ models:
 			name:            "missing overrides file returns all models",
 			noOverridesFile: true,
 			expectedTables: []string{
-				"fct_attestation",
-				"fct_block",
-				"fct_block_head",
-				"fct_block_summary",
-				"fct_proposer_slashing",
+				fctAttestation,
+				fctBlock,
+				fctBlockHead,
+				fctBlockSummary,
+				fctProposerSlashing,
 			},
 		},
 		{
@@ -127,8 +136,8 @@ models:
     fct_block_summary: {}
 `,
 			expectedTables: []string{
-				"fct_block",
-				"fct_block_summary",
+				fctBlock,
+				fctBlockSummary,
 			},
 		},
 		{
@@ -151,7 +160,7 @@ models:
       enabled: false
 `,
 			expectedTables: []string{
-				"fct_block",
+				fctBlock,
 			},
 		},
 	}
@@ -203,36 +212,36 @@ func TestDiscoverAllModels(t *testing.T) {
 	t.Run("models without database frontmatter", func(t *testing.T) {
 		repoDir := setupFakeXatuCBTRepo(
 			t,
-			[]string{"fct_block", "fct_attestation"},
-			[]string{"fct_summary"},
+			[]string{fctBlock, fctAttestation},
+			[]string{fctSummary},
 		)
 
 		models, err := discoverAllModels(repoDir)
 		require.NoError(t, err)
 		assert.Equal(t, []string{
-			"fct_attestation",
-			"fct_block",
-			"fct_summary",
+			fctAttestation,
+			fctBlock,
+			fctSummary,
 		}, models)
 	})
 
 	t.Run("external models with database frontmatter use prefixed keys", func(t *testing.T) {
 		repoDir := setupFakeXatuCBTRepo(
 			t,
-			[]string{"cpu_utilization", "fct_block"},
-			[]string{"fct_summary"},
+			[]string{"cpu_utilization", fctBlock},
+			[]string{fctSummary},
 		)
 
 		// Add database frontmatter to cpu_utilization to simulate observoor.
 		sqlWithFrontmatter := "---\ndatabase: observoor\ntable: cpu_utilization\n---\nSELECT 1"
-		path := filepath.Join(repoDir, "models", "external", "cpu_utilization.sql")
+		path := filepath.Join(repoDir, keyModels, "external", "cpu_utilization.sql")
 		require.NoError(t, os.WriteFile(path, []byte(sqlWithFrontmatter), 0600))
 
 		models, err := discoverAllModels(repoDir)
 		require.NoError(t, err)
 		assert.Equal(t, []string{
-			"fct_block",
-			"fct_summary",
+			fctBlock,
+			fctSummary,
 			"observoor.cpu_utilization",
 		}, models)
 	})
@@ -259,10 +268,10 @@ models:
 		states, err := loadModelStates(overridesPath)
 		require.NoError(t, err)
 		assert.True(t, states.defaultEnabled)
-		assert.True(t, states.disabled["fct_block"])
-		assert.True(t, states.disabled["fct_attestation"])
-		assert.False(t, states.disabled["fct_block_head"])
-		assert.True(t, states.enabled["fct_block_head"])
+		assert.True(t, states.disabled[fctBlock])
+		assert.True(t, states.disabled[fctAttestation])
+		assert.False(t, states.disabled[fctBlockHead])
+		assert.True(t, states.enabled[fctBlockHead])
 	})
 
 	t.Run("allowlist mode", func(t *testing.T) {
@@ -284,8 +293,8 @@ models:
 		states, err := loadModelStates(overridesPath)
 		require.NoError(t, err)
 		assert.False(t, states.defaultEnabled)
-		assert.True(t, states.enabled["fct_block"])
-		assert.True(t, states.disabled["fct_attestation"])
+		assert.True(t, states.enabled[fctBlock])
+		assert.True(t, states.disabled[fctAttestation])
 	})
 }
 
@@ -303,8 +312,8 @@ func TestRemoveEmptyMaps(t *testing.T) {
 		{
 			name: "removes empty nested map",
 			input: map[string]any{
-				"models": map[string]any{
-					"env": map[string]any{},
+				keyModels: map[string]any{
+					keyEnv: map[string]any{},
 				},
 			},
 			expected: map[string]any{},
@@ -312,16 +321,16 @@ func TestRemoveEmptyMaps(t *testing.T) {
 		{
 			name: "preserves non-empty nested map",
 			input: map[string]any{
-				"models": map[string]any{
-					"env": map[string]any{
-						"NETWORK": "mainnet",
+				keyModels: map[string]any{
+					keyEnv: map[string]any{
+						keyNetwork: networkMainnet,
 					},
 				},
 			},
 			expected: map[string]any{
-				"models": map[string]any{
-					"env": map[string]any{
-						"NETWORK": "mainnet",
+				keyModels: map[string]any{
+					keyEnv: map[string]any{
+						keyNetwork: networkMainnet,
 					},
 				},
 			},
@@ -329,17 +338,17 @@ func TestRemoveEmptyMaps(t *testing.T) {
 		{
 			name: "removes only empty branches",
 			input: map[string]any{
-				"models": map[string]any{
-					"env":    map[string]any{},
+				keyModels: map[string]any{
+					keyEnv:   map[string]any{},
 					"config": "keep-me",
 				},
-				"other": "value",
+				"other": keyValue,
 			},
 			expected: map[string]any{
-				"models": map[string]any{
+				keyModels: map[string]any{
 					"config": "keep-me",
 				},
-				"other": "value",
+				"other": keyValue,
 			},
 		},
 		{
@@ -367,19 +376,19 @@ func TestRemoveEmptyMaps(t *testing.T) {
 
 func TestEmptyOverrideDoesNotWipeAutoDefaults(t *testing.T) {
 	baseConfig := map[string]any{
-		"models": map[string]any{
-			"env": map[string]any{
-				"NETWORK":                      "mainnet",
-				"EXTERNAL_MODEL_MIN_TIMESTAMP": "1234567890",
-				"EXTERNAL_MODEL_MIN_BLOCK":     "23800000",
-				"MODELS_SCRIPTS_PATH":          "../xatu-cbt/models/scripts",
+		keyModels: map[string]any{
+			keyEnv: map[string]any{
+				keyNetwork:                   networkMainnet,
+				envExternalModelMinTimestamp: "1234567890",
+				envExternalModelMinBlock:     "23800000",
+				envModelsScriptsPath:         modelsScriptsPath,
 			},
 		},
 	}
 
 	userOverrides := map[string]any{
-		"models": map[string]any{
-			"env": map[string]any{},
+		keyModels: map[string]any{
+			keyEnv: map[string]any{},
 		},
 	}
 
@@ -388,34 +397,34 @@ func TestEmptyOverrideDoesNotWipeAutoDefaults(t *testing.T) {
 	err := mergo.Merge(&baseConfig, userOverrides, mergo.WithOverride)
 	require.NoError(t, err)
 
-	models, ok := baseConfig["models"].(map[string]any)
+	models, ok := baseConfig[keyModels].(map[string]any)
 	require.True(t, ok, "models section must exist")
 
-	env, ok := models["env"].(map[string]any)
+	env, ok := models[keyEnv].(map[string]any)
 	require.True(t, ok, "models.env section must exist")
 
-	assert.Equal(t, "mainnet", env["NETWORK"])
-	assert.Equal(t, "1234567890", env["EXTERNAL_MODEL_MIN_TIMESTAMP"])
-	assert.Equal(t, "23800000", env["EXTERNAL_MODEL_MIN_BLOCK"])
-	assert.Equal(t, "../xatu-cbt/models/scripts", env["MODELS_SCRIPTS_PATH"])
+	assert.Equal(t, networkMainnet, env[keyNetwork])
+	assert.Equal(t, "1234567890", env[envExternalModelMinTimestamp])
+	assert.Equal(t, "23800000", env[envExternalModelMinBlock])
+	assert.Equal(t, modelsScriptsPath, env[envModelsScriptsPath])
 }
 
 func TestUserOverridesTakePrecedence(t *testing.T) {
 	baseConfig := map[string]any{
-		"models": map[string]any{
-			"env": map[string]any{
-				"NETWORK":                      "mainnet",
-				"EXTERNAL_MODEL_MIN_TIMESTAMP": "1234567890",
-				"EXTERNAL_MODEL_MIN_BLOCK":     "23800000",
+		keyModels: map[string]any{
+			keyEnv: map[string]any{
+				keyNetwork:                   networkMainnet,
+				envExternalModelMinTimestamp: "1234567890",
+				envExternalModelMinBlock:     "23800000",
 			},
 		},
 	}
 
 	userOverrides := map[string]any{
-		"models": map[string]any{
-			"env": map[string]any{
-				"EXTERNAL_MODEL_MIN_TIMESTAMP": "0",
-				"EXTERNAL_MODEL_MIN_BLOCK":     "0",
+		keyModels: map[string]any{
+			keyEnv: map[string]any{
+				envExternalModelMinTimestamp: "0",
+				envExternalModelMinBlock:     "0",
 			},
 		},
 	}
@@ -425,25 +434,25 @@ func TestUserOverridesTakePrecedence(t *testing.T) {
 	err := mergo.Merge(&baseConfig, userOverrides, mergo.WithOverride)
 	require.NoError(t, err)
 
-	models, ok := baseConfig["models"].(map[string]any)
+	models, ok := baseConfig[keyModels].(map[string]any)
 	require.True(t, ok)
 
-	env, ok := models["env"].(map[string]any)
+	env, ok := models[keyEnv].(map[string]any)
 	require.True(t, ok)
 
-	assert.Equal(t, "0", env["EXTERNAL_MODEL_MIN_TIMESTAMP"])
-	assert.Equal(t, "0", env["EXTERNAL_MODEL_MIN_BLOCK"])
-	assert.Equal(t, "mainnet", env["NETWORK"])
+	assert.Equal(t, "0", env[envExternalModelMinTimestamp])
+	assert.Equal(t, "0", env[envExternalModelMinBlock])
+	assert.Equal(t, networkMainnet, env[keyNetwork])
 }
 
 func TestCommentOnlyEnvOverrideDoesNotWipeAutoDefaults(t *testing.T) {
 	baseConfig := map[string]any{
-		"models": map[string]any{
-			"env": map[string]any{
-				"NETWORK":                      "mainnet",
-				"EXTERNAL_MODEL_MIN_TIMESTAMP": "1234567890",
-				"EXTERNAL_MODEL_MIN_BLOCK":     "23800000",
-				"MODELS_SCRIPTS_PATH":          "../xatu-cbt/models/scripts",
+		keyModels: map[string]any{
+			keyEnv: map[string]any{
+				keyNetwork:                   networkMainnet,
+				envExternalModelMinTimestamp: "1234567890",
+				envExternalModelMinBlock:     "23800000",
+				envModelsScriptsPath:         modelsScriptsPath,
 			},
 		},
 	}
@@ -465,22 +474,22 @@ models:
 	err = mergo.Merge(&baseConfig, userOverrides, mergo.WithOverride)
 	require.NoError(t, err)
 
-	models, ok := baseConfig["models"].(map[string]any)
+	models, ok := baseConfig[keyModels].(map[string]any)
 	require.True(t, ok)
 
-	env, ok := models["env"].(map[string]any)
+	env, ok := models[keyEnv].(map[string]any)
 	require.True(t, ok, "models.env section must remain populated")
 
-	assert.Equal(t, "mainnet", env["NETWORK"])
-	assert.Equal(t, "1234567890", env["EXTERNAL_MODEL_MIN_TIMESTAMP"])
-	assert.Equal(t, "23800000", env["EXTERNAL_MODEL_MIN_BLOCK"])
-	assert.Equal(t, "../xatu-cbt/models/scripts", env["MODELS_SCRIPTS_PATH"])
+	assert.Equal(t, networkMainnet, env[keyNetwork])
+	assert.Equal(t, "1234567890", env[envExternalModelMinTimestamp])
+	assert.Equal(t, "23800000", env[envExternalModelMinBlock])
+	assert.Equal(t, modelsScriptsPath, env[envModelsScriptsPath])
 }
 
 func TestExpandDefaultEnabled(t *testing.T) {
 	t.Run("no defaultEnabled does nothing", func(t *testing.T) {
 		repoDir := setupFakeXatuCBTRepo(t,
-			[]string{"fct_block", "fct_attestation"}, nil,
+			[]string{fctBlock, fctAttestation}, nil,
 		)
 
 		gen := NewGenerator(logrus.New(), &config.LabConfig{
@@ -488,30 +497,30 @@ func TestExpandDefaultEnabled(t *testing.T) {
 		})
 
 		overrides := map[string]any{
-			"models": map[string]any{
-				"overrides": map[string]any{
-					"fct_block": map[string]any{},
+			keyModels: map[string]any{
+				keyOverrides: map[string]any{
+					fctBlock: map[string]any{},
 				},
 			},
 		}
 
 		gen.expandDefaultEnabled(overrides)
 
-		models, ok := overrides["models"].(map[string]any)
+		models, ok := overrides[keyModels].(map[string]any)
 		require.True(t, ok)
 
-		ov, ok := models["overrides"].(map[string]any)
+		ov, ok := models[keyOverrides].(map[string]any)
 		require.True(t, ok)
 
 		// Only the original entry should exist.
 		assert.Len(t, ov, 1)
-		assert.Contains(t, ov, "fct_block")
+		assert.Contains(t, ov, fctBlock)
 	})
 
 	t.Run("defaultEnabled false expands unlisted models", func(t *testing.T) {
 		repoDir := setupFakeXatuCBTRepo(t,
-			[]string{"fct_block", "fct_attestation", "fct_proposer"},
-			[]string{"fct_summary"},
+			[]string{fctBlock, fctAttestation, "fct_proposer"},
+			[]string{fctSummary},
 		)
 
 		gen := NewGenerator(logrus.New(), &config.LabConfig{
@@ -519,27 +528,27 @@ func TestExpandDefaultEnabled(t *testing.T) {
 		})
 
 		overrides := map[string]any{
-			"models": map[string]any{
+			keyModels: map[string]any{
 				"defaultEnabled": false,
-				"overrides": map[string]any{
-					"fct_block": map[string]any{},
+				keyOverrides: map[string]any{
+					fctBlock: map[string]any{},
 				},
 			},
 		}
 
 		gen.expandDefaultEnabled(overrides)
 
-		models, ok := overrides["models"].(map[string]any)
+		models, ok := overrides[keyModels].(map[string]any)
 		require.True(t, ok)
 
-		ov, ok := models["overrides"].(map[string]any)
+		ov, ok := models[keyOverrides].(map[string]any)
 		require.True(t, ok)
 
 		// fct_block should be untouched (still listed, no enabled:false injected).
-		assert.Equal(t, map[string]any{}, ov["fct_block"])
+		assert.Equal(t, map[string]any{}, ov[fctBlock])
 
 		// All other models should have enabled: false injected.
-		for _, name := range []string{"fct_attestation", "fct_proposer", "fct_summary"} {
+		for _, name := range []string{fctAttestation, "fct_proposer", fctSummary} {
 			entry, ok := ov[name]
 			require.True(t, ok, "expected %s to be injected", name)
 
@@ -555,7 +564,7 @@ func TestExpandDefaultEnabled(t *testing.T) {
 
 	t.Run("defaultEnabled true does nothing", func(t *testing.T) {
 		repoDir := setupFakeXatuCBTRepo(t,
-			[]string{"fct_block", "fct_attestation"}, nil,
+			[]string{fctBlock, fctAttestation}, nil,
 		)
 
 		gen := NewGenerator(logrus.New(), &config.LabConfig{
@@ -563,20 +572,20 @@ func TestExpandDefaultEnabled(t *testing.T) {
 		})
 
 		overrides := map[string]any{
-			"models": map[string]any{
+			keyModels: map[string]any{
 				"defaultEnabled": true,
-				"overrides": map[string]any{
-					"fct_block": map[string]any{},
+				keyOverrides: map[string]any{
+					fctBlock: map[string]any{},
 				},
 			},
 		}
 
 		gen.expandDefaultEnabled(overrides)
 
-		models, ok := overrides["models"].(map[string]any)
+		models, ok := overrides[keyModels].(map[string]any)
 		require.True(t, ok)
 
-		ov, ok := models["overrides"].(map[string]any)
+		ov, ok := models[keyOverrides].(map[string]any)
 		require.True(t, ok)
 
 		// Should not inject anything.

--- a/pkg/configgen/observability.go
+++ b/pkg/configgen/observability.go
@@ -13,6 +13,28 @@ import (
 	"github.com/ethpandaops/xcli/pkg/configgen/dashboards"
 )
 
+const (
+	keyList       = "list"
+	keyID         = "id"
+	keyPanels     = "panels"
+	keyTitle      = "title"
+	keyUID        = "uid"
+	keyGridPos    = "gridPos"
+	keyType       = "type"
+	keyDatasource = "datasource"
+	keyColor      = "color"
+	keyMode       = "mode"
+	keyText       = "text"
+	keyValue      = "value"
+	keyThresholds = "thresholds"
+	keyOptions    = "options"
+
+	valPrometheus = "prometheus"
+	valGreen      = "green"
+	valNone       = "none"
+	valAuto       = "auto"
+)
+
 // grafanaDatasourceConfig is the static Grafana datasource provisioning YAML.
 const grafanaDatasourceConfig = `apiVersion: 1
 datasources:
@@ -293,18 +315,18 @@ func (g *Generator) generateLabDashboard(outputPath string) error {
 
 	dashboard := map[string]any{
 		"annotations": map[string]any{
-			"list": []any{},
+			keyList: []any{},
 		},
 		"editable":             true,
 		"fiscalYearStartMonth": 0,
 		"graphTooltip":         0,
-		"id":                   nil,
+		keyID:                  nil,
 		"links":                []any{},
-		"panels":               panels,
+		keyPanels:              panels,
 		"schemaVersion":        39,
 		"tags":                 []string{"lab", "xcli"},
 		"templating": map[string]any{
-			"list": []any{},
+			keyList: []any{},
 		},
 		"time": map[string]any{
 			"from": "now-1h",
@@ -312,8 +334,8 @@ func (g *Generator) generateLabDashboard(outputPath string) error {
 		},
 		"timepicker": map[string]any{},
 		"timezone":   "browser",
-		"title":      "Lab Overview",
-		"uid":        "xcli-lab-overview",
+		keyTitle:     "Lab Overview",
+		keyUID:       "xcli-lab-overview",
 		"version":    1,
 		"weekStart":  "",
 	}
@@ -340,11 +362,11 @@ func (g *Generator) buildDashboardPanels() []any {
 	// Service health row
 	panels = append(panels, map[string]any{
 		"collapsed": false,
-		"gridPos":   map[string]any{"h": 1, "w": 24, "x": 0, "y": gridY},
-		"id":        1,
-		"panels":    []any{},
-		"title":     "Service Health",
-		"type":      "row",
+		keyGridPos:  map[string]any{"h": 1, "w": 24, "x": 0, "y": gridY},
+		keyID:       1,
+		keyPanels:   []any{},
+		keyTitle:    "Service Health",
+		keyType:     "row",
 	})
 	gridY++
 
@@ -387,11 +409,11 @@ func (g *Generator) buildDashboardPanels() []any {
 	// Go runtime metrics row
 	panels = append(panels, map[string]any{
 		"collapsed": false,
-		"gridPos":   map[string]any{"h": 1, "w": 24, "x": 0, "y": gridY},
-		"id":        panelID,
-		"panels":    []any{},
-		"title":     "Go Runtime",
-		"type":      "row",
+		keyGridPos:  map[string]any{"h": 1, "w": 24, "x": 0, "y": gridY},
+		keyID:       panelID,
+		keyPanels:   []any{},
+		keyTitle:    "Go Runtime",
+		keyType:     "row",
 	})
 	panelID++
 	gridY++
@@ -419,62 +441,62 @@ func (g *Generator) buildDashboardPanels() []any {
 // createStatPanel creates a Grafana stat panel configuration.
 func (g *Generator) createStatPanel(id int, title, query string, x, y, w, h int) map[string]any {
 	return map[string]any{
-		"datasource": map[string]any{
-			"type": "prometheus",
-			"uid":  "prometheus",
+		keyDatasource: map[string]any{
+			keyType: valPrometheus,
+			keyUID:  valPrometheus,
 		},
 		"fieldConfig": map[string]any{
 			"defaults": map[string]any{
-				"color": map[string]any{
-					"mode": "thresholds",
+				keyColor: map[string]any{
+					keyMode: "thresholds",
 				},
 				"mappings": []any{
 					map[string]any{
-						"options": map[string]any{
+						keyOptions: map[string]any{
 							"0": map[string]any{
-								"color": "red",
-								"index": 1,
-								"text":  "Down",
+								keyColor: "red",
+								"index":  1,
+								keyText:  "Down",
 							},
 							"1": map[string]any{
-								"color": "green",
-								"index": 0,
-								"text":  "Up",
+								keyColor: valGreen,
+								"index":  0,
+								keyText:  "Up",
 							},
 						},
-						"type": "value",
+						keyType: keyValue,
 					},
 				},
-				"thresholds": map[string]any{
-					"mode": "absolute",
+				keyThresholds: map[string]any{
+					keyMode: "absolute",
 					"steps": []any{
-						map[string]any{"color": "red", "value": nil},
-						map[string]any{"color": "green", "value": 1},
+						map[string]any{keyColor: "red", keyValue: nil},
+						map[string]any{keyColor: valGreen, keyValue: 1},
 					},
 				},
 			},
-			"overrides": []any{},
+			keyOverrides: []any{},
 		},
-		"gridPos": map[string]any{"h": h, "w": w, "x": x, "y": y},
-		"id":      id,
-		"options": map[string]any{
-			"colorMode":   "value",
-			"graphMode":   "none",
-			"justifyMode": "auto",
-			"orientation": "auto",
+		keyGridPos: map[string]any{"h": h, "w": w, "x": x, "y": y},
+		keyID:      id,
+		keyOptions: map[string]any{
+			"colorMode":   keyValue,
+			"graphMode":   valNone,
+			"justifyMode": valAuto,
+			"orientation": valAuto,
 			"reduceOptions": map[string]any{
 				"calcs":  []string{"lastNotNull"},
 				"fields": "",
 				"values": false,
 			},
-			"textMode": "auto",
+			"textMode": valAuto,
 		},
 		"pluginVersion": "11.3.1",
 		"targets": []any{
 			map[string]any{
-				"datasource": map[string]any{
-					"type": "prometheus",
-					"uid":  "prometheus",
+				keyDatasource: map[string]any{
+					keyType: valPrometheus,
+					keyUID:  valPrometheus,
 				},
 				"expr":         query,
 				"instant":      true,
@@ -482,33 +504,33 @@ func (g *Generator) createStatPanel(id int, title, query string, x, y, w, h int)
 				"refId":        "A",
 			},
 		},
-		"title": title,
-		"type":  "stat",
+		keyTitle: title,
+		keyType:  "stat",
 	}
 }
 
 // createTimeSeriesPanel creates a Grafana time series panel configuration.
 func (g *Generator) createTimeSeriesPanel(id int, title, query string, x, y, w, h int) map[string]any {
 	return map[string]any{
-		"datasource": map[string]any{
-			"type": "prometheus",
-			"uid":  "prometheus",
+		keyDatasource: map[string]any{
+			keyType: valPrometheus,
+			keyUID:  valPrometheus,
 		},
 		"fieldConfig": map[string]any{
 			"defaults": map[string]any{
-				"color": map[string]any{
-					"mode": "palette-classic",
+				keyColor: map[string]any{
+					keyMode: "palette-classic",
 				},
 				"custom": map[string]any{
 					"axisBorderShow":   false,
 					"axisCenteredZero": false,
-					"axisColorMode":    "text",
+					"axisColorMode":    keyText,
 					"axisLabel":        "",
-					"axisPlacement":    "auto",
+					"axisPlacement":    valAuto,
 					"barAlignment":     0,
 					"drawStyle":        "line",
 					"fillOpacity":      10,
-					"gradientMode":     "none",
+					"gradientMode":     valNone,
 					"hideFrom": map[string]any{
 						"legend":  false,
 						"tooltip": false,
@@ -519,54 +541,54 @@ func (g *Generator) createTimeSeriesPanel(id int, title, query string, x, y, w, 
 					"lineWidth":         1,
 					"pointSize":         5,
 					"scaleDistribution": map[string]any{
-						"type": "linear",
+						keyType: "linear",
 					},
-					"showPoints": "auto",
+					"showPoints": valAuto,
 					"spanNulls":  false,
 					"stacking": map[string]any{
 						"group": "A",
-						"mode":  "none",
+						keyMode: valNone,
 					},
 					"thresholdsStyle": map[string]any{
-						"mode": "off",
+						keyMode: "off",
 					},
 				},
 				"mappings": []any{},
-				"thresholds": map[string]any{
-					"mode": "absolute",
+				keyThresholds: map[string]any{
+					keyMode: "absolute",
 					"steps": []any{
-						map[string]any{"color": "green", "value": nil},
+						map[string]any{keyColor: valGreen, keyValue: nil},
 					},
 				},
 			},
-			"overrides": []any{},
+			keyOverrides: []any{},
 		},
-		"gridPos": map[string]any{"h": h, "w": w, "x": x, "y": y},
-		"id":      id,
-		"options": map[string]any{
+		keyGridPos: map[string]any{"h": h, "w": w, "x": x, "y": y},
+		keyID:      id,
+		keyOptions: map[string]any{
 			"legend": map[string]any{
 				"calcs":       []any{},
-				"displayMode": "list",
+				"displayMode": keyList,
 				"placement":   "bottom",
 				"showLegend":  true,
 			},
 			"tooltip": map[string]any{
-				"mode": "single",
-				"sort": "none",
+				keyMode: "single",
+				"sort":  valNone,
 			},
 		},
 		"targets": []any{
 			map[string]any{
-				"datasource": map[string]any{
-					"type": "prometheus",
-					"uid":  "prometheus",
+				keyDatasource: map[string]any{
+					keyType: valPrometheus,
+					keyUID:  valPrometheus,
 				},
 				"expr":         query,
 				"legendFormat": "{{job}}",
 				"refId":        "A",
 			},
 		},
-		"title": title,
-		"type":  "timeseries",
+		keyTitle: title,
+		keyType:  "timeseries",
 	}
 }

--- a/pkg/configtui/overrides_test.go
+++ b/pkg/configtui/overrides_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testModelFctBlock = "fct_block"
+
 func TestIsModelDisabled(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -20,7 +22,7 @@ func TestIsModelDisabled(t *testing.T) {
 		{
 			name:      "nil overrides returns false",
 			overrides: nil,
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -28,7 +30,7 @@ func TestIsModelDisabled(t *testing.T) {
 			overrides: &CBTOverrides{
 				Models: ModelsConfig{},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -38,7 +40,7 @@ func TestIsModelDisabled(t *testing.T) {
 					Overrides: map[string]ModelOverride{},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -46,11 +48,11 @@ func TestIsModelDisabled(t *testing.T) {
 			overrides: &CBTOverrides{
 				Models: ModelsConfig{
 					Overrides: map[string]ModelOverride{
-						"fct_block": {Enabled: new(false)},
+						testModelFctBlock: {Enabled: new(false)},
 					},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  true,
 		},
 		{
@@ -58,11 +60,11 @@ func TestIsModelDisabled(t *testing.T) {
 			overrides: &CBTOverrides{
 				Models: ModelsConfig{
 					Overrides: map[string]ModelOverride{
-						"fct_block": {Enabled: new(true)},
+						testModelFctBlock: {Enabled: new(true)},
 					},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -70,11 +72,11 @@ func TestIsModelDisabled(t *testing.T) {
 			overrides: &CBTOverrides{
 				Models: ModelsConfig{
 					Overrides: map[string]ModelOverride{
-						"fct_block": {},
+						testModelFctBlock: {},
 					},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -85,7 +87,7 @@ func TestIsModelDisabled(t *testing.T) {
 					Overrides:      map[string]ModelOverride{},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  true,
 		},
 		{
@@ -94,11 +96,11 @@ func TestIsModelDisabled(t *testing.T) {
 				Models: ModelsConfig{
 					DefaultEnabled: new(false),
 					Overrides: map[string]ModelOverride{
-						"fct_block": {},
+						testModelFctBlock: {},
 					},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 		{
@@ -107,11 +109,11 @@ func TestIsModelDisabled(t *testing.T) {
 				Models: ModelsConfig{
 					DefaultEnabled: new(false),
 					Overrides: map[string]ModelOverride{
-						"fct_block": {Enabled: new(false)},
+						testModelFctBlock: {Enabled: new(false)},
 					},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  true,
 		},
 		{
@@ -121,7 +123,7 @@ func TestIsModelDisabled(t *testing.T) {
 					DefaultEnabled: new(false),
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  true,
 		},
 		{
@@ -132,7 +134,7 @@ func TestIsModelDisabled(t *testing.T) {
 					Overrides:      map[string]ModelOverride{},
 				},
 			},
-			modelName: "fct_block",
+			modelName: testModelFctBlock,
 			expected:  false,
 		},
 	}
@@ -168,7 +170,7 @@ models:
 		require.NoError(t, err)
 		assert.True(t, exists)
 		assert.Nil(t, overrides.Models.DefaultEnabled)
-		assert.True(t, IsModelDisabled(overrides, "fct_block"))
+		assert.True(t, IsModelDisabled(overrides, testModelFctBlock))
 		assert.False(t, IsModelDisabled(overrides, "fct_other"))
 	})
 
@@ -190,7 +192,7 @@ models:
 		require.NotNil(t, overrides.Models.DefaultEnabled)
 		assert.False(t, *overrides.Models.DefaultEnabled)
 		// fct_block is listed → enabled
-		assert.False(t, IsModelDisabled(overrides, "fct_block"))
+		assert.False(t, IsModelDisabled(overrides, testModelFctBlock))
 		// fct_attestation is listed with enabled:false → disabled
 		assert.True(t, IsModelDisabled(overrides, "fct_attestation"))
 		// fct_other is unlisted → disabled (allowlist mode)
@@ -343,7 +345,7 @@ func TestSaveOverridesFromEntries_PreservesConfig(t *testing.T) {
 	existing := &CBTOverrides{
 		Models: ModelsConfig{
 			Overrides: map[string]ModelOverride{
-				"fct_block": {
+				testModelFctBlock: {
 					Enabled: new(false),
 					Config:  map[string]any{"limits": map[string]any{"min": 42}},
 				},
@@ -353,7 +355,7 @@ func TestSaveOverridesFromEntries_PreservesConfig(t *testing.T) {
 
 	err := SaveOverridesFromEntries(
 		path,
-		[]ModelEntry{{Name: "fct_block", OverrideKey: "fct_block", Enabled: false}},
+		[]ModelEntry{{Name: testModelFctBlock, OverrideKey: testModelFctBlock, Enabled: false}},
 		nil,
 		"", false, "", false,
 		existing,

--- a/pkg/diagnostic/analysis.go
+++ b/pkg/diagnostic/analysis.go
@@ -10,6 +10,10 @@ import (
 	"github.com/ethpandaops/xcli/pkg/ai"
 )
 
+// redactedReplacement is the replacement string used to mask secret values
+// while preserving the matched key name.
+const redactedReplacement = "$1=[REDACTED]"
+
 // AIDiagnosis is a backward-compatible alias for the shared diagnosis report type.
 type AIDiagnosis = ai.DiagnosisReport
 
@@ -243,11 +247,11 @@ func sanitizeOutput(output string) string {
 		pattern *regexp.Regexp
 		replace string
 	}{
-		{regexp.MustCompile(`(?i)(API_KEY|APIKEY|API-KEY)\s*[=:]\s*[^\s]+`), "$1=[REDACTED]"},
-		{regexp.MustCompile(`(?i)(TOKEN|AUTH_TOKEN|ACCESS_TOKEN)\s*[=:]\s*[^\s]+`), "$1=[REDACTED]"},
-		{regexp.MustCompile(`(?i)(SECRET|SECRET_KEY|PRIVATE_KEY)\s*[=:]\s*[^\s]+`), "$1=[REDACTED]"},
-		{regexp.MustCompile(`(?i)(PASSWORD|PASSWD|PWD)\s*[=:]\s*[^\s]+`), "$1=[REDACTED]"},
-		{regexp.MustCompile(`(?i)(CREDENTIAL|CRED)\s*[=:]\s*[^\s]+`), "$1=[REDACTED]"},
+		{regexp.MustCompile(`(?i)(API_KEY|APIKEY|API-KEY)\s*[=:]\s*[^\s]+`), redactedReplacement},
+		{regexp.MustCompile(`(?i)(TOKEN|AUTH_TOKEN|ACCESS_TOKEN)\s*[=:]\s*[^\s]+`), redactedReplacement},
+		{regexp.MustCompile(`(?i)(SECRET|SECRET_KEY|PRIVATE_KEY)\s*[=:]\s*[^\s]+`), redactedReplacement},
+		{regexp.MustCompile(`(?i)(PASSWORD|PASSWD|PWD)\s*[=:]\s*[^\s]+`), redactedReplacement},
+		{regexp.MustCompile(`(?i)(CREDENTIAL|CRED)\s*[=:]\s*[^\s]+`), redactedReplacement},
 		{regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._-]+`), "bearer [REDACTED]"},
 		{regexp.MustCompile(`(?i)authorization:\s*[^\n]+`), "authorization: [REDACTED]"},
 	}

--- a/pkg/diagnostic/patterns.go
+++ b/pkg/diagnostic/patterns.go
@@ -5,6 +5,18 @@ import (
 	"strings"
 )
 
+// Confidence levels for diagnosis results.
+const (
+	confidenceHigh   = "high"
+	confidenceMedium = "medium"
+	confidenceLow    = "low"
+)
+
+// Common substrings used in error pattern matching.
+const (
+	substrNotFound = "not found"
+)
+
 // ErrorPattern defines a known error pattern and its corresponding hint.
 type ErrorPattern struct {
 	// Name is a unique identifier for this pattern.
@@ -211,11 +223,11 @@ func (m *PatternMatcher) calculateMatchScore(pattern *ErrorPattern, lowerOutput,
 
 	// Bonus for confidence level
 	switch pattern.Confidence {
-	case "high":
+	case confidenceHigh:
 		score += 5
-	case "medium":
+	case confidenceMedium:
 		score += 3
-	case "low":
+	case confidenceLow:
 		score += 1
 	}
 
@@ -257,7 +269,7 @@ func (m *PatternMatcher) registerProtoPatterns() {
   3. Circular dependencies between proto files
 
 Run: make proto -C <repo> with verbose output to see which file has the error`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "proto-type-mismatch",
@@ -270,7 +282,7 @@ Run: make proto -C <repo> with verbose output to see which file has the error`,
   3. Enum values used where messages are expected
 
 Ensure all proto files are regenerated together: xcli lab rebuild xatu-cbt`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "proto-import-not-found",
@@ -283,7 +295,7 @@ Ensure all proto files are regenerated together: xcli lab rebuild xatu-cbt`,
   3. Ensure google/protobuf imports are available
 
 You may need to run: make proto-deps or install protobuf dependencies`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "proto-syntax-error",
@@ -296,11 +308,11 @@ You may need to run: make proto-deps or install protobuf dependencies`,
   3. Invalid field numbers or reserved keywords
 
 Run protoc with --error_format=text for clearer error messages`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:     "protoc-not-found",
-			Contains: []string{"protoc", "not found"},
+			Contains: []string{"protoc", substrNotFound},
 			Phase:    PhaseProtoGen,
 			Hint:     "The protoc compiler is not installed or not in PATH.",
 			Suggestion: `Install protoc:
@@ -308,7 +320,7 @@ Run protoc with --error_format=text for clearer error messages`,
   Linux: apt install protobuf-compiler
 
 Then verify: protoc --version`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 	)
 }
@@ -328,7 +340,7 @@ func (m *PatternMatcher) registerGoBuildPatterns() {
   4. Stale generated code that needs regeneration
 
 Run: go build -v to see detailed compilation info`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-missing-package",
@@ -341,7 +353,7 @@ Run: go build -v to see detailed compilation info`,
   3. go mod download - download all dependencies
 
 If using a local replace directive, verify the path exists`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-import-cycle",
@@ -354,7 +366,7 @@ If using a local replace directive, verify the path exists`,
   3. Restructuring code to have clear dependency direction
 
 Use: go list -deps ./... | sort | uniq -d to find cycles`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:     "go-too-many-errors",
@@ -367,7 +379,7 @@ Use: go list -deps ./... | sort | uniq -d to find cycles`,
   3. Many subsequent errors will likely disappear
 
 Often caused by missing import or undefined type that's used everywhere`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 		ErrorPattern{
 			Name:    "go-type-mismatch",
@@ -380,7 +392,7 @@ Often caused by missing import or undefined type that's used everywhere`,
   3. Interface implementation mismatch
 
 If this involves generated code, regenerate protos: xcli lab rebuild xatu-cbt`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-not-enough-arguments",
@@ -393,7 +405,7 @@ If this involves generated code, regenerate protos: xcli lab rebuild xatu-cbt`,
   3. If using generated code, regenerate it first
 
 Run: go doc <package>.<Function> to see current signature`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-too-many-arguments",
@@ -404,7 +416,7 @@ Run: go doc <package>.<Function> to see current signature`,
   1. The function may have been updated with fewer parameters
   2. Remove extra arguments from call sites
   3. If using generated code, regenerate it first`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-no-new-variables",
@@ -420,7 +432,7 @@ Run: go doc <package>.<Function> to see current signature`,
   // Correct:
   x := 1
   x = 2`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-declared-not-used",
@@ -431,7 +443,7 @@ Run: go doc <package>.<Function> to see current signature`,
   1. Use the variable where intended
   2. Remove the declaration
   3. Use _ to explicitly ignore: _ = unusedVar`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-imported-not-used",
@@ -444,7 +456,7 @@ Run: go doc <package>.<Function> to see current signature`,
   3. Use blank import if needed for side effects: import _ "package"
 
 Run: goimports -w . to auto-fix imports`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "go-mod-tidy-needed",
@@ -455,7 +467,7 @@ Run: goimports -w . to auto-fix imports`,
   go mod tidy
 
 This will update both go.mod and go.sum to match your imports`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 	)
 }
@@ -474,7 +486,7 @@ func (m *PatternMatcher) registerPnpmPatterns() {
   3. Check import path is correct
 
 For generated types: xcli lab rebuild lab-frontend`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "ts-type-error-2304",
@@ -487,7 +499,7 @@ For generated types: xcli lab rebuild lab-frontend`,
   3. Generated types need regeneration
 
 For API types: xcli lab rebuild lab-frontend`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "ts-type-error-2305",
@@ -500,7 +512,7 @@ For API types: xcli lab rebuild lab-frontend`,
   3. Default vs named export mismatch
 
 If importing from generated code, regenerate: xcli lab rebuild lab-frontend`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "pnpm-enoent",
@@ -513,7 +525,7 @@ If importing from generated code, regenerate: xcli lab rebuild lab-frontend`,
   3. Check if a build step needs to run first
 
 For missing generated files: xcli lab rebuild lab-frontend`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "pnpm-specific-error",
@@ -526,7 +538,7 @@ For missing generated files: xcli lab rebuild lab-frontend`,
   3. Check pnpm version: pnpm --version
 
 See pnpm documentation for the specific error code`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 		ErrorPattern{
 			Name:     "pnpm-peer-deps",
@@ -537,7 +549,7 @@ See pnpm documentation for the specific error code`,
   1. pnpm install - should auto-install peers
   2. Manually install: pnpm add <peer-package>
   3. Check package.json for version compatibility`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 		ErrorPattern{
 			Name:    "ts-strict-null-checks",
@@ -548,7 +560,7 @@ See pnpm documentation for the specific error code`,
   1. Use optional chaining: obj?.property
   2. Add null check: if (obj !== null)
   3. Use non-null assertion if certain: obj!.property`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "vite-build-error",
@@ -561,7 +573,7 @@ See pnpm documentation for the specific error code`,
   3. Verify all imports are correct
 
 For HMR issues, try: rm -rf .vite && pnpm dev`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 	)
 }
@@ -579,7 +591,7 @@ func (m *PatternMatcher) registerMakePatterns() {
   3. You're in the correct directory
 
 List available targets: make help (if available)`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "make-recipe-failed",
@@ -591,7 +603,7 @@ List available targets: make help (if available)`,
   3. Check prerequisites are met
 
 Run with verbose: make <target> V=1`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 		ErrorPattern{
 			Name:     "make-missing-separator",
@@ -602,7 +614,7 @@ Run with verbose: make <target> V=1`,
   2. Don't mix tabs and spaces
 
 Check with: cat -A Makefile | grep "^ " (should show ^I for tabs)`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "make-circular-dependency",
@@ -612,7 +624,7 @@ Check with: cat -A Makefile | grep "^ " (should show ^I for tabs)`,
   1. Target A depends on B, and B depends on A
   2. Restructure dependencies to be acyclic
   3. Use .PHONY for non-file targets`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 	)
 }
@@ -632,7 +644,7 @@ Or wait for it to be ready:
   docker logs xcli-clickhouse --follow
 
 Check status: xcli lab status`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:     "redis-not-ready",
@@ -644,7 +656,7 @@ Check status: xcli lab status`,
 
 Check status: xcli lab status
 View logs: docker logs xcli-redis`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "port-already-in-use",
@@ -659,7 +671,7 @@ Or change the port in your config:
   xcli lab config
 
 Then restart: xcli lab restart`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "cbt-api-not-ready",
@@ -673,21 +685,21 @@ Or check logs:
   xcli lab logs cbt-api-<network>
 
 Start services if not running: xcli lab up`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:     "config-not-found",
-			Contains: []string{"config", "not found", ".xcli"},
+			Contains: []string{"config", substrNotFound, ".xcli"},
 			Hint:     "xcli configuration file not found. The lab may not be initialized.",
 			Suggestion: `Initialize xcli:
   xcli init
 
 Or check you're in the correct directory with .xcli.yaml`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:     "repo-not-found",
-			Contains: []string{"repository", "not found"},
+			Contains: []string{"repository", substrNotFound},
 			Hint:     "A required repository is not found at the configured path.",
 			Suggestion: `Check repository paths in config:
   xcli lab config
@@ -696,7 +708,7 @@ Clone missing repos:
   xcli init
 
 Or run prerequisites: xcli lab check`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "permission-denied",
@@ -708,7 +720,7 @@ Or run prerequisites: xcli lab check`,
   3. Docker permissions: ensure user is in docker group
 
 For Docker: sudo usermod -aG docker $USER && newgrp docker`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "network-timeout",
@@ -722,7 +734,7 @@ Increase timeout or check:
   1. Service is running: docker ps
   2. Network connectivity: ping localhost
   3. Resource usage: docker stats`,
-			Confidence: "medium",
+			Confidence: confidenceMedium,
 		},
 		ErrorPattern{
 			Name:    "database-connection-error",
@@ -736,7 +748,7 @@ Ensure ClickHouse is running:
   docker logs xcli-clickhouse
 
 Start services: xcli lab up`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 	)
 }
@@ -753,7 +765,7 @@ func (m *PatternMatcher) registerDockerPatterns() {
   Linux: sudo systemctl start docker
 
 Verify: docker info`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "docker-image-not-found",
@@ -765,7 +777,7 @@ Verify: docker info`,
   3. Pull manually: docker pull <image>
 
 For local images: docker build -t <name> .`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "docker-container-conflict",
@@ -777,7 +789,7 @@ For local images: docker build -t <name> .`,
 Or use a different name.
 
 Clean up all xcli containers: xcli lab down`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "docker-no-space",
@@ -789,7 +801,7 @@ Clean up all xcli containers: xcli lab down`,
 Check space: docker system df
 
 Increase Docker disk space in Docker Desktop settings`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 		ErrorPattern{
 			Name:    "docker-network-error",
@@ -802,7 +814,7 @@ Create if needed:
   docker network create xcli
 
 Clean up: xcli lab down && xcli lab up`,
-			Confidence: "high",
+			Confidence: confidenceHigh,
 		},
 	)
 }
@@ -810,9 +822,9 @@ Clean up: xcli lab down && xcli lab up`,
 // sortDiagnosesByConfidence sorts diagnoses with high confidence first.
 func sortDiagnosesByConfidence(diagnoses []*Diagnosis) {
 	confidenceOrder := map[string]int{
-		"high":   3,
-		"medium": 2,
-		"low":    1,
+		confidenceHigh:   3,
+		confidenceMedium: 2,
+		confidenceLow:    1,
 	}
 
 	// Simple bubble sort for small slices

--- a/pkg/diagnostic/store.go
+++ b/pkg/diagnostic/store.go
@@ -18,6 +18,11 @@ const (
 
 	// defaultRetention is the default retention period for diagnostic reports.
 	defaultRetention = 7 * 24 * time.Hour // 7 days
+
+	// logFieldFile is the logrus field key for a file name.
+	logFieldFile = "file"
+	// logFieldError is the logrus field key for an error value.
+	logFieldError = "error"
 )
 
 // Store handles persistence of diagnostic reports.
@@ -58,8 +63,8 @@ func (s *Store) Save(report *RebuildReport) error {
 	}
 
 	s.log.WithFields(logrus.Fields{
-		"id":   report.ID,
-		"file": filename,
+		"id":         report.ID,
+		logFieldFile: filename,
 	}).Debug("saved diagnostic report")
 
 	// Automatically clean up old reports to prevent buildup
@@ -107,8 +112,8 @@ func (s *Store) Load(id string) (*RebuildReport, error) {
 			}
 
 			s.log.WithFields(logrus.Fields{
-				"id":   id,
-				"file": name,
+				"id":         id,
+				logFieldFile: name,
 			}).Debug("loaded diagnostic report")
 
 			return &report, nil
@@ -160,8 +165,8 @@ func (s *Store) List(limit int) ([]*RebuildReport, error) {
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			s.log.WithFields(logrus.Fields{
-				"file":  name,
-				"error": err,
+				logFieldFile:  name,
+				logFieldError: err,
 			}).Warn("failed to read report file, skipping")
 
 			continue
@@ -170,8 +175,8 @@ func (s *Store) List(limit int) ([]*RebuildReport, error) {
 		var report RebuildReport
 		if err := json.Unmarshal(data, &report); err != nil {
 			s.log.WithFields(logrus.Fields{
-				"file":  name,
-				"error": err,
+				logFieldFile:  name,
+				logFieldError: err,
 			}).Warn("failed to unmarshal report, skipping")
 
 			continue
@@ -235,8 +240,8 @@ func (s *Store) Cleanup(retention time.Duration) error {
 		fileTime, err := time.Parse(timestampFormat, timestampStr)
 		if err != nil {
 			s.log.WithFields(logrus.Fields{
-				"file":  name,
-				"error": err,
+				logFieldFile:  name,
+				logFieldError: err,
 			}).Warn("failed to parse timestamp from filename, skipping")
 
 			continue
@@ -248,8 +253,8 @@ func (s *Store) Cleanup(retention time.Duration) error {
 
 			if err := os.Remove(filePath); err != nil {
 				s.log.WithFields(logrus.Fields{
-					"file":  name,
-					"error": err,
+					logFieldFile:  name,
+					logFieldError: err,
 				}).Warn("failed to remove old report")
 
 				continue

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -36,10 +36,10 @@ func (d *Discovery) DiscoverRepos(ctx context.Context) (*config.LabReposConfig, 
 
 	repos := &config.LabReposConfig{
 		CBT:        filepath.Join(d.basePath, "cbt"),
-		XatuCBT:    filepath.Join(d.basePath, "xatu-cbt"),
+		XatuCBT:    filepath.Join(d.basePath, constants.RepoXatuCBT),
 		CBTAPI:     filepath.Join(d.basePath, "cbt-api"),
 		LabBackend: filepath.Join(d.basePath, "lab-backend"),
-		Lab:        filepath.Join(d.basePath, "lab"),
+		Lab:        filepath.Join(d.basePath, constants.RepoLab),
 	}
 
 	// Map of repo names to their paths, GitHub repo names, and optional branches
@@ -48,11 +48,11 @@ func (d *Discovery) DiscoverRepos(ctx context.Context) (*config.LabReposConfig, 
 		repoName string
 		branch   string // Optional: branch to checkout after cloning
 	}{
-		"cbt":         {&repos.CBT, constants.RepoCBT, ""},
-		"xatu-cbt":    {&repos.XatuCBT, constants.RepoXatuCBT, ""},
-		"cbt-api":     {&repos.CBTAPI, constants.RepoCBTAPI, ""},
-		"lab-backend": {&repos.LabBackend, constants.RepoLabBackend, ""},
-		"lab":         {&repos.Lab, constants.RepoLab, "release/frontend"},
+		"cbt":                 {&repos.CBT, constants.RepoCBT, ""},
+		constants.RepoXatuCBT: {&repos.XatuCBT, constants.RepoXatuCBT, ""},
+		"cbt-api":             {&repos.CBTAPI, constants.RepoCBTAPI, ""},
+		"lab-backend":         {&repos.LabBackend, constants.RepoLabBackend, ""},
+		constants.RepoLab:     {&repos.Lab, constants.RepoLab, "release/frontend"},
 	}
 
 	// Check each repository
@@ -140,12 +140,12 @@ func (d *Discovery) validateRepo(name, path string) error {
 
 	// Check for expected files based on repo type
 	switch name {
-	case "cbt", "xatu-cbt", "cbt-api", "lab-backend":
+	case "cbt", constants.RepoXatuCBT, "cbt-api", "lab-backend":
 		// Go repositories - check for go.mod
 		if !d.fileExists(filepath.Join(absPath, "go.mod")) {
 			return fmt.Errorf("go.mod not found (not a Go project)")
 		}
-	case "lab":
+	case constants.RepoLab:
 		// Frontend repository - check for package.json
 		if !d.fileExists(filepath.Join(absPath, "package.json")) {
 			return fmt.Errorf("package.json not found (not a Node.js project)")
@@ -154,12 +154,12 @@ func (d *Discovery) validateRepo(name, path string) error {
 
 	// Additional validation for specific repos
 	switch name {
-	case "xatu-cbt":
+	case constants.RepoXatuCBT:
 		// Check for models directory
 		if !d.dirExists(filepath.Join(absPath, "models")) {
 			return fmt.Errorf("models directory not found")
 		}
-	case "lab":
+	case constants.RepoLab:
 		// Check for src directory
 		if !d.dirExists(filepath.Join(absPath, "src")) {
 			return fmt.Errorf("src directory not found")

--- a/pkg/infrastructure/bounds_seeder.go
+++ b/pkg/infrastructure/bounds_seeder.go
@@ -25,6 +25,13 @@ const (
 	// luaDumpExternalBounds is a Lua script that fetches all external bounds keys and values
 	// in a single Redis round trip. Returns alternating key/value pairs.
 	luaDumpExternalBounds = `local keys = redis.call('KEYS', ARGV[1]) local result = {} for i, key in ipairs(keys) do result[#result + 1] = key result[#result + 1] = redis.call('GET', key) end return result`
+
+	// cmdExec is the docker/kubectl exec subcommand.
+	cmdExec = "exec"
+	// cmdRedisCLI is the redis-cli command name.
+	cmdRedisCLI = "redis-cli"
+	// flagN is the "-n" flag (redis-cli database number / kubectl namespace).
+	flagN = "-n"
 )
 
 // BoundsSeeder handles seeding CBT external bounds from production Redis.
@@ -95,9 +102,9 @@ func (s *BoundsSeeder) SeedFromProduction(ctx context.Context, network string, r
 // CheckNeedsSeeding checks if local Redis has any external bounds for the given network.
 func (s *BoundsSeeder) CheckNeedsSeeding(ctx context.Context, redisDB int) (bool, error) {
 	args := []string{
-		"exec", localRedisContainer,
-		"redis-cli",
-		"-n", fmt.Sprintf("%d", redisDB),
+		cmdExec, localRedisContainer,
+		cmdRedisCLI,
+		flagN, fmt.Sprintf("%d", redisDB),
 		"KEYS", redisBoundsKeyPrefix + "*",
 	}
 
@@ -128,7 +135,7 @@ func (s *BoundsSeeder) checkKubectl(ctx context.Context) error {
 func (s *BoundsSeeder) getRedisPassword(ctx context.Context, secretName string) (string, error) {
 	args := []string{
 		"--context", prodK8sContext,
-		"-n", prodNamespace,
+		flagN, prodNamespace,
 		"get", "secret", secretName,
 		"-o", "jsonpath={.data.redis-password}",
 	}
@@ -156,11 +163,11 @@ func (s *BoundsSeeder) fetchAllBounds(ctx context.Context, network, password str
 
 	args := []string{
 		"--context", prodK8sContext,
-		"-n", prodNamespace,
-		"exec", podName,
+		flagN, prodNamespace,
+		cmdExec, podName,
 		"-c", "redis",
 		"--",
-		"redis-cli",
+		cmdRedisCLI,
 		"-a", password,
 		"--no-auth-warning",
 		"EVAL", luaDumpExternalBounds,
@@ -230,9 +237,9 @@ func (s *BoundsSeeder) bulkInsertLocal(ctx context.Context, redisDB int, bounds 
 	}
 
 	args := []string{
-		"exec", "-i", localRedisContainer,
-		"redis-cli",
-		"-n", fmt.Sprintf("%d", redisDB),
+		cmdExec, "-i", localRedisContainer,
+		cmdRedisCLI,
+		flagN, fmt.Sprintf("%d", redisDB),
 		"--pipe",
 	}
 

--- a/pkg/infrastructure/manager.go
+++ b/pkg/infrastructure/manager.go
@@ -35,7 +35,7 @@ const (
 
 	// clickHouseClusterHostPrefix is the hostname prefix for ClickHouse clusters.
 	// When this prefix is detected, additional DNS checks are performed for individual shards.
-	clickHouseClusterHostPrefix = "chendpoint-xatu-clickhouse"
+	clickHouseClusterHostPrefix = "chendpoint-clickhouse-raw"
 )
 
 // clickHouseClusterShards are the shard suffixes for ClickHouse clusters.
@@ -103,9 +103,27 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Build command arguments
 	args := []string{"infra", "start", "--xatu-source", xatuSource}
 
-	// Add external Xatu URL if in external mode
+	// Add external Xatu URL if in external mode. Credentials configured via the
+	// separate externalUsername/externalPassword fields must be embedded into the
+	// URL, since xatu-cbt reads them only from the URL when generating its cluster
+	// config.
+	//
+	// Trade-off: embedding credentials means the password appears in this child
+	// process's command line (world-readable via /proc/<pid>/cmdline on Linux)
+	// for the lifetime of the short-lived `infra start` call. xatu-cbt's
+	// infra-start currently has no env/file alternative to the --xatu-url flag;
+	// switching to an env var (as the builder path uses) would require a change
+	// there. The password is also already persisted to disk in xatu-cbt's
+	// generated ClickHouse config, so this does not introduce on-disk exposure.
 	if xatuSource == constants.InfraModeExternal {
-		args = append(args, "--xatu-url", m.cfg.Infrastructure.ClickHouse.Xatu.ExternalURL)
+		xatuURL, urlErr := m.cfg.Infrastructure.ClickHouse.Xatu.ExternalURLWithCredentials()
+		if urlErr != nil {
+			spinner.Fail("Failed to start infrastructure services")
+
+			return fmt.Errorf("failed to build external Xatu URL: %w", urlErr)
+		}
+
+		args = append(args, "--xatu-url", xatuURL)
 	}
 
 	// Add xatu ref if configured
@@ -573,7 +591,7 @@ func (m *Manager) checkPort(ctx context.Context, addr string) bool {
 }
 
 // checkClusterShardDNS performs DNS lookups for individual shard endpoints
-// when the configured host matches a ClickHouse cluster (e.g., chendpoint-xatu-clickhouse).
+// when the configured host matches a ClickHouse cluster (e.g., chendpoint-clickhouse-raw).
 // This helps diagnose connectivity issues to specific shards in the cluster.
 func (m *Manager) checkClusterShardDNS(ctx context.Context, host string) error {
 	// Extract the first component of the hostname

--- a/pkg/infrastructure/manager.go
+++ b/pkg/infrastructure/manager.go
@@ -36,6 +36,9 @@ const (
 	// clickHouseClusterHostPrefix is the hostname prefix for ClickHouse clusters.
 	// When this prefix is detected, additional DNS checks are performed for individual shards.
 	clickHouseClusterHostPrefix = "chendpoint-clickhouse-raw"
+
+	// logFieldHost is the structured log field key for a host.
+	logFieldHost = "host"
 )
 
 // clickHouseClusterShards are the shard suffixes for ClickHouse clusters.
@@ -389,9 +392,9 @@ func (m *Manager) TestExternalConnection(ctx context.Context) error {
 	args = append(args, "--query", "SELECT 1")
 
 	m.log.WithFields(logrus.Fields{
-		"host": host,
-		"port": port,
-		"user": username,
+		logFieldHost: host,
+		"port":       port,
+		"user":       username,
 	}).Debug("testing external ClickHouse connection")
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
@@ -619,9 +622,9 @@ func (m *Manager) checkClusterShardDNS(ctx context.Context, host string) error {
 			ui.Error(fmt.Sprintf("DNS lookup failed for shard %s: %s", shard, shardHost))
 
 			m.log.WithFields(logrus.Fields{
-				"shard": shard,
-				"host":  shardHost,
-				"error": err.Error(),
+				"shard":      shard,
+				logFieldHost: shardHost,
+				"error":      err.Error(),
 			}).Warn("DNS lookup failed for shard")
 
 			dnsErrors = append(dnsErrors, fmt.Sprintf("%s: %v", shardHost, err))
@@ -629,8 +632,8 @@ func (m *Manager) checkClusterShardDNS(ctx context.Context, host string) error {
 			ui.Success(fmt.Sprintf("DNS OK for shard %s: %s", shard, shardHost))
 
 			m.log.WithFields(logrus.Fields{
-				"shard": shard,
-				"host":  shardHost,
+				"shard":      shard,
+				logFieldHost: shardHost,
 			}).Debug("DNS lookup successful for shard")
 		}
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -28,6 +28,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Service status values and log field keys.
+const (
+	statusRunning   = "running"
+	logFieldService = "service"
+)
+
 // ProgressFunc reports stack boot progress.
 // phase is a short identifier, message is human-readable.
 type ProgressFunc func(phase string, message string)
@@ -414,12 +420,12 @@ func (o *Orchestrator) Up(
 		{
 			Name:   "Lab Frontend",
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.Ports.LabFrontend),
-			Status: "running",
+			Status: statusRunning,
 		},
 		{
 			Name:   "Lab Backend",
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.Ports.LabBackend),
-			Status: "running",
+			Status: statusRunning,
 		},
 	}
 
@@ -427,12 +433,12 @@ func (o *Orchestrator) Up(
 		services = append(services, ui.Service{
 			Name:   fmt.Sprintf("CBT API (%s)", net.Name),
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.GetCBTAPIPort(net.Name)),
-			Status: "running",
+			Status: statusRunning,
 		})
 		services = append(services, ui.Service{
 			Name:   fmt.Sprintf("CBT Frontend (%s)", net.Name),
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.GetCBTFrontendPort(net.Name)),
-			Status: "running",
+			Status: statusRunning,
 		})
 	}
 
@@ -441,12 +447,12 @@ func (o *Orchestrator) Up(
 		services = append(services, ui.Service{
 			Name:   "Prometheus",
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.Infrastructure.Observability.PrometheusPort),
-			Status: "running",
+			Status: statusRunning,
 		})
 		services = append(services, ui.Service{
 			Name:   "Grafana",
 			URL:    fmt.Sprintf("http://localhost:%d", o.cfg.Infrastructure.Observability.GrafanaPort),
-			Status: "running",
+			Status: statusRunning,
 		})
 	}
 
@@ -589,7 +595,7 @@ func (o *Orchestrator) Restart(ctx context.Context, service string) error {
 		return fmt.Errorf("failed to stop service: %w", err)
 	}
 
-	o.log.WithField("service", service).Info("service stopped, starting again")
+	o.log.WithField(logFieldService, service).Info("service stopped, starting again")
 
 	// Start the service
 	if err := o.StartService(ctx, service); err != nil {
@@ -780,7 +786,7 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 
 		status := "down"
 		if running {
-			status = "running"
+			status = statusRunning
 		}
 
 		infraServices = append(infraServices, ui.Service{
@@ -796,7 +802,7 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 		infraServices = append(infraServices, ui.Service{
 			Name:   "ClickHouse Xatu (external)",
 			URL:    externalInfo,
-			Status: "running",
+			Status: statusRunning,
 		})
 	}
 
@@ -816,7 +822,7 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 			for name, status := range obsStatus {
 				state := "down"
 				if status.Running {
-					state = "running"
+					state = statusRunning
 				}
 
 				url := fmt.Sprintf("http://localhost:%d", status.Port)
@@ -849,7 +855,7 @@ func (o *Orchestrator) Status(ctx context.Context) error {
 			services = append(services, ui.Service{
 				Name:   p.Name,
 				URL:    url,
-				Status: "running",
+				Status: statusRunning,
 			})
 		}
 
@@ -1144,11 +1150,11 @@ func (o *Orchestrator) checkGitStatus(ctx context.Context) {
 
 	// Build map of repositories to check
 	repos := map[string]string{
-		"cbt":         o.cfg.Repos.CBT,
-		"xatu-cbt":    o.cfg.Repos.XatuCBT,
-		"cbt-api":     o.cfg.Repos.CBTAPI,
-		"lab-backend": o.cfg.Repos.LabBackend,
-		"lab":         o.cfg.Repos.Lab,
+		"cbt":                    o.cfg.Repos.CBT,
+		"xatu-cbt":               o.cfg.Repos.XatuCBT,
+		"cbt-api":                o.cfg.Repos.CBTAPI,
+		constants.RepoLabBackend: o.cfg.Repos.LabBackend,
+		"lab":                    o.cfg.Repos.Lab,
 	}
 
 	o.log.Info("checking git status for all repositories")
@@ -1241,11 +1247,11 @@ func (o *Orchestrator) validatePrerequisites(ctx context.Context) error {
 
 	// Check that all required repositories exist
 	requiredRepos := map[string]string{
-		"cbt":         o.cfg.Repos.CBT,
-		"xatu-cbt":    o.cfg.Repos.XatuCBT,
-		"cbt-api":     o.cfg.Repos.CBTAPI,
-		"lab-backend": o.cfg.Repos.LabBackend,
-		"lab":         o.cfg.Repos.Lab,
+		"cbt":                    o.cfg.Repos.CBT,
+		"xatu-cbt":               o.cfg.Repos.XatuCBT,
+		"cbt-api":                o.cfg.Repos.CBTAPI,
+		constants.RepoLabBackend: o.cfg.Repos.LabBackend,
+		"lab":                    o.cfg.Repos.Lab,
 	}
 
 	for repoName, repoPath := range requiredRepos {
@@ -1343,8 +1349,8 @@ func (o *Orchestrator) cleanupOrphanedProcessesForService(service string) {
 	}
 
 	o.log.WithFields(logrus.Fields{
-		"service": service,
-		"ports":   ports,
+		logFieldService: service,
+		"ports":         ports,
 	}).Info("checking for orphaned processes")
 
 	conflicts := portutil.CheckPorts(ports)
@@ -1353,17 +1359,17 @@ func (o *Orchestrator) cleanupOrphanedProcessesForService(service string) {
 	}
 
 	o.log.WithFields(logrus.Fields{
-		"service":   service,
-		"conflicts": len(conflicts),
+		logFieldService: service,
+		"conflicts":     len(conflicts),
 	}).Info("found orphaned processes for service")
 
 	for _, conflict := range conflicts {
 		if conflict.PID > 0 {
 			o.log.WithFields(logrus.Fields{
-				"pid":     conflict.PID,
-				"port":    conflict.Port,
-				"service": service,
-				"process": conflict.Process,
+				"pid":           conflict.PID,
+				"port":          conflict.Port,
+				logFieldService: service,
+				"process":       conflict.Process,
 			}).Info("killing orphaned process for service")
 
 			if err := portutil.KillProcess(conflict.PID); err != nil {
@@ -1378,7 +1384,7 @@ func (o *Orchestrator) getServicePorts(service string) []int {
 	switch service {
 	case "lab-frontend":
 		return []int{o.cfg.Ports.LabFrontend}
-	case "lab-backend":
+	case constants.ServiceLabBackend:
 		port := o.cfg.Ports.LabBackend
 		if p := o.readConfigPort(constants.ConfigFileLabBackend); p != 0 {
 			port = p

--- a/pkg/prerequisites/known_repos.go
+++ b/pkg/prerequisites/known_repos.go
@@ -1,5 +1,8 @@
 package prerequisites
 
+// envFile is the default environment file name created from .env.example.
+const envFile = ".env"
+
 // buildKnownRepo returns prerequisite definitions for all known repos.
 func buildKnownRepo() map[string]Repo {
 	return map[string]Repo{
@@ -10,8 +13,8 @@ func buildKnownRepo() map[string]Repo {
 					Type:            TypeFileCopy,
 					Description:     "Copy .env.example to .env",
 					SourcePath:      ".env.example",
-					DestinationPath: ".env",
-					SkipIfExists:    ".env",
+					DestinationPath: envFile,
+					SkipIfExists:    envFile,
 				},
 			},
 		},
@@ -43,8 +46,8 @@ func buildKnownRepo() map[string]Repo {
 					Type:            TypeFileCopy,
 					Description:     "Copy example.env to .env",
 					SourcePath:      "example.env",
-					DestinationPath: ".env",
-					SkipIfExists:    ".env",
+					DestinationPath: envFile,
+					SkipIfExists:    envFile,
 				},
 			},
 		},

--- a/pkg/prerequisites/prerequisites_test.go
+++ b/pkg/prerequisites/prerequisites_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test fixture constants.
+const (
+	testSourceFile = "source.txt"
+	testDestFile   = "dest.txt"
+	testCopyDesc   = "Copy source to dest"
+	testRepoName   = "test-repo"
+)
+
 func TestExecuteFileCopy(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -23,14 +31,14 @@ func TestExecuteFileCopy(t *testing.T) {
 			setupFunc: func(t *testing.T, repoPath string) {
 				t.Helper()
 				// Create source file
-				err := os.WriteFile(filepath.Join(repoPath, "source.txt"), []byte("test content"), 0600)
+				err := os.WriteFile(filepath.Join(repoPath, testSourceFile), []byte("test content"), 0600)
 				require.NoError(t, err)
 			},
 			prereq: Prerequisite{
 				Type:            TypeFileCopy,
-				Description:     "Copy source to dest",
-				SourcePath:      "source.txt",
-				DestinationPath: "dest.txt",
+				Description:     testCopyDesc,
+				SourcePath:      testSourceFile,
+				DestinationPath: testDestFile,
 			},
 			expectError: false,
 		},
@@ -43,7 +51,7 @@ func TestExecuteFileCopy(t *testing.T) {
 				Type:            TypeFileCopy,
 				Description:     "Copy missing file",
 				SourcePath:      "missing.txt",
-				DestinationPath: "dest.txt",
+				DestinationPath: testDestFile,
 			},
 			expectError: true,
 		},
@@ -92,10 +100,10 @@ func TestExecuteFileCopySkipIfExists(t *testing.T) {
 	sourceContent := "source content"
 	destContent := "existing dest content"
 
-	err := os.WriteFile(filepath.Join(repoPath, "source.txt"), []byte(sourceContent), 0600)
+	err := os.WriteFile(filepath.Join(repoPath, testSourceFile), []byte(sourceContent), 0600)
 	require.NoError(t, err)
 
-	destPath := filepath.Join(repoPath, "dest.txt")
+	destPath := filepath.Join(repoPath, testDestFile)
 	err = os.WriteFile(destPath, []byte(destContent), 0600)
 	require.NoError(t, err)
 
@@ -105,15 +113,15 @@ func TestExecuteFileCopySkipIfExists(t *testing.T) {
 	testChecker := &checker{
 		log: log.WithField("component", "prerequisites"),
 		defs: map[string]Repo{
-			"test-repo": {
-				RepoName: "test-repo",
+			testRepoName: {
+				RepoName: testRepoName,
 				Prerequisites: []Prerequisite{
 					{
 						Type:            TypeFileCopy,
-						Description:     "Copy source to dest",
-						SourcePath:      "source.txt",
-						DestinationPath: "dest.txt",
-						SkipIfExists:    "dest.txt",
+						Description:     testCopyDesc,
+						SourcePath:      testSourceFile,
+						DestinationPath: testDestFile,
+						SkipIfExists:    testDestFile,
 					},
 				},
 			},
@@ -121,7 +129,7 @@ func TestExecuteFileCopySkipIfExists(t *testing.T) {
 	}
 
 	// Execute
-	err = testChecker.Run(context.Background(), repoPath, "test-repo")
+	err = testChecker.Run(context.Background(), repoPath, testRepoName)
 	require.NoError(t, err)
 
 	// Verify destination was NOT overwritten (skip condition worked)
@@ -298,7 +306,7 @@ func TestCheckAndRun(t *testing.T) {
 	repoPath := t.TempDir()
 
 	// Create source file
-	err := os.WriteFile(filepath.Join(repoPath, "source.txt"), []byte("test content"), 0600)
+	err := os.WriteFile(filepath.Join(repoPath, testSourceFile), []byte("test content"), 0600)
 	require.NoError(t, err)
 
 	// Create custom checker for testing
@@ -307,15 +315,15 @@ func TestCheckAndRun(t *testing.T) {
 	testChecker := &checker{
 		log: log.WithField("component", "prerequisites"),
 		defs: map[string]Repo{
-			"test-repo": {
-				RepoName: "test-repo",
+			testRepoName: {
+				RepoName: testRepoName,
 				Prerequisites: []Prerequisite{
 					{
 						Type:            TypeFileCopy,
-						Description:     "Copy source to dest",
-						SourcePath:      "source.txt",
-						DestinationPath: "dest.txt",
-						SkipIfExists:    "dest.txt",
+						Description:     testCopyDesc,
+						SourcePath:      testSourceFile,
+						DestinationPath: testDestFile,
+						SkipIfExists:    testDestFile,
 					},
 				},
 			},
@@ -323,17 +331,17 @@ func TestCheckAndRun(t *testing.T) {
 	}
 
 	// First run - should execute prerequisite
-	err = testChecker.CheckAndRun(context.Background(), repoPath, "test-repo")
+	err = testChecker.CheckAndRun(context.Background(), repoPath, testRepoName)
 	require.NoError(t, err)
 
 	// Verify file was copied
-	destPath := filepath.Join(repoPath, "dest.txt")
+	destPath := filepath.Join(repoPath, testDestFile)
 	content, err := os.ReadFile(destPath)
 	require.NoError(t, err)
 	assert.Equal(t, "test content", string(content))
 
 	// Second run - should skip (idempotent)
-	err = testChecker.CheckAndRun(context.Background(), repoPath, "test-repo")
+	err = testChecker.CheckAndRun(context.Background(), repoPath, testRepoName)
 	require.NoError(t, err)
 
 	// Verify file still exists with same content
@@ -354,17 +362,17 @@ func TestCheck(t *testing.T) {
 			setupFunc: func(t *testing.T, repoPath string) {
 				t.Helper()
 
-				err := os.WriteFile(filepath.Join(repoPath, "dest.txt"), []byte("content"), 0600)
+				err := os.WriteFile(filepath.Join(repoPath, testDestFile), []byte("content"), 0600)
 				require.NoError(t, err)
 			},
 			prereqs: Repo{
-				RepoName: "test-repo",
+				RepoName: testRepoName,
 				Prerequisites: []Prerequisite{
 					{
 						Type:            TypeFileCopy,
 						Description:     "Copy file",
-						SourcePath:      "source.txt",
-						DestinationPath: "dest.txt",
+						SourcePath:      testSourceFile,
+						DestinationPath: testDestFile,
 					},
 				},
 			},
@@ -376,12 +384,12 @@ func TestCheck(t *testing.T) {
 				t.Helper()
 			},
 			prereqs: Repo{
-				RepoName: "test-repo",
+				RepoName: testRepoName,
 				Prerequisites: []Prerequisite{
 					{
 						Type:            TypeFileCopy,
 						Description:     "Copy file",
-						SourcePath:      "source.txt",
+						SourcePath:      testSourceFile,
 						DestinationPath: "missing.txt",
 					},
 				},
@@ -404,12 +412,12 @@ func TestCheck(t *testing.T) {
 			testChecker := &checker{
 				log: log.WithField("component", "prerequisites"),
 				defs: map[string]Repo{
-					"test-repo": tt.prereqs,
+					testRepoName: tt.prereqs,
 				},
 			}
 
 			// Execute check
-			err := testChecker.Check(context.Background(), repoPath, "test-repo")
+			err := testChecker.Check(context.Background(), repoPath, testRepoName)
 
 			// Assert
 			if tt.expectError {

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -23,6 +23,11 @@ const (
 	// shutdownPollInterval is how often to check if a process has stopped.
 	shutdownPollInterval = 100 * time.Millisecond
 	pidFileVersion       = 1
+
+	// logFieldName is the structured log field key for a process name.
+	logFieldName = "name"
+	// logFieldPID is the structured log field key for a process PID.
+	logFieldPID = "pid"
 )
 
 // Compile-time interface check.
@@ -130,8 +135,8 @@ func (m *manager) Start(ctx context.Context, name string, cmd *exec.Cmd, healthC
 
 	// Run health check after starting
 	m.log.WithFields(logrus.Fields{
-		"name":         name,
-		"pid":          process.PID,
+		logFieldName:   name,
+		logFieldPID:    process.PID,
 		"health_check": healthCheck.Name(),
 	}).Debug("running health check")
 
@@ -146,7 +151,7 @@ func (m *manager) Start(ctx context.Context, name string, cmd *exec.Cmd, healthC
 		return fmt.Errorf("health check failed: %w", err)
 	}
 
-	m.log.WithField("name", name).Info("process started and healthy")
+	m.log.WithField(logFieldName, name).Info("process started and healthy")
 
 	// Monitor process in background
 	go m.monitor(name, process, logFd)
@@ -166,8 +171,8 @@ func (m *manager) Stop(ctx context.Context, name string) error {
 	}
 
 	m.log.WithFields(logrus.Fields{
-		"name": name,
-		"pid":  p.PID,
+		logFieldName: name,
+		logFieldPID:  p.PID,
 	}).Info("stopping process")
 
 	// Get process handle (works for both started and loaded processes)
@@ -196,7 +201,7 @@ func (m *manager) Stop(ctx context.Context, name string) error {
 		select {
 		case <-ctx.Done():
 			// Context cancelled - force kill immediately
-			m.log.WithField("name", name).Warn("Context cancelled, sending SIGKILL")
+			m.log.WithField(logFieldName, name).Warn("Context cancelled, sending SIGKILL")
 
 			_ = syscall.Kill(-p.PID, syscall.SIGKILL)
 
@@ -210,7 +215,7 @@ func (m *manager) Stop(ctx context.Context, name string) error {
 			return ctx.Err()
 		case <-timeout:
 			// Graceful shutdown timeout - force kill
-			m.log.WithField("name", name).Warn("Process did not stop gracefully, sending SIGKILL")
+			m.log.WithField(logFieldName, name).Warn("Process did not stop gracefully, sending SIGKILL")
 
 			_ = syscall.Kill(-p.PID, syscall.SIGKILL)
 
@@ -250,7 +255,7 @@ func (m *manager) StopAll(ctx context.Context) error {
 				name := entry.Name()[:len(entry.Name())-4]
 				// Only load if not already in memory
 				if _, exists := m.processes[name]; !exists {
-					m.log.WithField("name", name).Debug(
+					m.log.WithField(logFieldName, name).Debug(
 						"found orphaned PID file, attempting to load",
 					)
 					m.loadPID(name)
@@ -275,8 +280,8 @@ func (m *manager) StopAll(ctx context.Context) error {
 	for _, name := range names {
 		if err := m.Stop(ctx, name); err != nil {
 			m.log.WithFields(logrus.Fields{
-				"name":  name,
-				"error": err,
+				logFieldName: name,
+				"error":      err,
 			}).Warn("failed to stop process")
 			errs = append(errs, fmt.Errorf("stop %s: %w", name, err))
 		}
@@ -469,14 +474,14 @@ func (m *manager) monitor(name string, p *Process, logFd *os.File) {
 
 	if err != nil {
 		m.log.WithFields(logrus.Fields{
-			"name": name,
-			"pid":  p.PID,
-			"err":  err,
+			logFieldName: name,
+			logFieldPID:  p.PID,
+			"err":        err,
 		}).Warn("Process exited with error")
 	} else {
 		m.log.WithFields(logrus.Fields{
-			"name": name,
-			"pid":  p.PID,
+			logFieldName: name,
+			logFieldPID:  p.PID,
 		}).Info("Process exited")
 	}
 }
@@ -552,7 +557,7 @@ func (m *manager) loadPIDsLocked() {
 				delete(m.processes, name)
 				m.removePID(name)
 
-				m.log.WithField("name", name).Debug("removed stale PID-loaded process")
+				m.log.WithField(logFieldName, name).Debug("removed stale PID-loaded process")
 			}
 
 			continue
@@ -570,8 +575,8 @@ func (m *manager) loadPID(name string) {
 	content, err := os.ReadFile(pidFile)
 	if err != nil {
 		m.log.WithFields(logrus.Fields{
-			"name":    name,
-			"pidFile": pidFile,
+			logFieldName: name,
+			"pidFile":    pidFile,
 		}).Debug("failed to read PID file")
 
 		return
@@ -580,7 +585,7 @@ func (m *manager) loadPID(name string) {
 	var data PIDFileData
 	if unmarshalErr := json.Unmarshal(content, &data); unmarshalErr != nil {
 		m.log.WithFields(logrus.Fields{
-			"name": name,
+			logFieldName: name,
 		}).Warn("failed to parse PID file, removing stale file")
 		m.removePID(name)
 
@@ -616,7 +621,7 @@ func (m *manager) loadPID(name string) {
 	}
 
 	m.log.WithFields(logrus.Fields{
-		"name": name,
-		"pid":  data.PID,
+		logFieldName: name,
+		logFieldPID:  data.PID,
 	}).Debug("loaded process from PID file")
 }

--- a/pkg/seeddata/assertions.go
+++ b/pkg/seeddata/assertions.go
@@ -57,8 +57,8 @@ func (c *ClaudeAssertionClient) GenerateAssertions(ctx context.Context, transfor
 	prompt := c.buildAssertionPrompt(transformationSQL, externalModels, modelName)
 
 	c.log.WithFields(logrus.Fields{
-		"timeout": c.timeout,
-		"model":   modelName,
+		"timeout":     c.timeout,
+		fieldKeyModel: modelName,
 	}).Debug("invoking AI engine for assertion generation")
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)

--- a/pkg/seeddata/discovery.go
+++ b/pkg/seeddata/discovery.go
@@ -22,6 +22,12 @@ import (
 // ExpandWindowMultiplier defines how much to expand the window on each retry.
 const ExpandWindowMultiplier = 2
 
+// Field keys used in log fields and template metadata maps.
+const (
+	fieldKeyModel   = "model"
+	fieldKeyNetwork = "network"
+)
+
 // RangeColumnType identifies the semantic type of a range column.
 type RangeColumnType string
 
@@ -176,12 +182,12 @@ func (c *ClaudeDiscoveryClient) GatherSchemaInfo(
 	schemas := make([]TableSchemaInfo, 0, len(models))
 
 	for _, model := range models {
-		c.log.WithField("model", model).Debug("gathering schema info")
+		c.log.WithField(fieldKeyModel, model).Debug("gathering schema info")
 
 		// Get interval type from model frontmatter (informational context for Claude)
 		intervalType, err := GetExternalModelIntervalType(model, xatuCBTPath)
 		if err != nil {
-			c.log.WithError(err).WithField("model", model).Warn("failed to get interval type")
+			c.log.WithError(err).WithField(fieldKeyModel, model).Warn("failed to get interval type")
 
 			intervalType = IntervalTypeSlot // Default to slot
 		}
@@ -201,7 +207,7 @@ func (c *ClaudeDiscoveryClient) GatherSchemaInfo(
 		// Try to detect range column from SQL file
 		rangeCol, detectErr := DetectRangeColumnForModel(model, xatuCBTPath)
 		if detectErr != nil {
-			c.log.WithError(detectErr).WithField("model", model).Debug("failed to detect range column from SQL")
+			c.log.WithError(detectErr).WithField(fieldKeyModel, model).Debug("failed to detect range column from SQL")
 
 			// For tables without a detected range column, find any time column in schema
 			// This handles entity tables and other tables without explicit range definitions
@@ -221,7 +227,7 @@ func (c *ClaudeDiscoveryClient) GatherSchemaInfo(
 		case RangeColumnTypeBlock, RangeColumnTypeSlot, RangeColumnTypeEpoch:
 			rawRange, rangeErr := c.gen.QueryModelRangeRaw(ctx, model, network, rangeCol)
 			if rangeErr != nil {
-				c.log.WithError(rangeErr).WithField("model", model).Warn("failed to query model range")
+				c.log.WithError(rangeErr).WithField(fieldKeyModel, model).Warn("failed to query model range")
 			} else {
 				minVal = rawRange.MinRaw
 				maxVal = rawRange.MaxRaw
@@ -229,7 +235,7 @@ func (c *ClaudeDiscoveryClient) GatherSchemaInfo(
 		default:
 			modelRange, rangeErr := c.gen.QueryModelRange(ctx, model, network, rangeCol)
 			if rangeErr != nil {
-				c.log.WithError(rangeErr).WithField("model", model).Warn("failed to query model range")
+				c.log.WithError(rangeErr).WithField(fieldKeyModel, model).Warn("failed to query model range")
 			} else {
 				minVal = modelRange.MinRaw
 				maxVal = modelRange.MaxRaw
@@ -239,7 +245,7 @@ func (c *ClaudeDiscoveryClient) GatherSchemaInfo(
 		// Get sample data (limited to 3 rows for prompt size)
 		sampleData, sampleErr := c.gen.QueryTableSample(ctx, model, network, 3)
 		if sampleErr != nil {
-			c.log.WithError(sampleErr).WithField("model", model).Warn("failed to query sample data")
+			c.log.WithError(sampleErr).WithField(fieldKeyModel, model).Warn("failed to query sample data")
 			// Continue without sample data - not critical
 		}
 
@@ -270,8 +276,8 @@ func (c *ClaudeDiscoveryClient) AnalyzeRanges(
 	prompt := c.buildDiscoveryPrompt(input)
 
 	c.log.WithFields(logrus.Fields{
-		"timeout": c.timeout,
-		"model":   input.TransformationModel,
+		"timeout":     c.timeout,
+		fieldKeyModel: input.TransformationModel,
 	}).Debug("invoking AI engine for range discovery")
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
@@ -408,10 +414,10 @@ func (g *Generator) QueryRowCount(
 	}
 
 	g.log.WithFields(logrus.Fields{
-		"model":   model,
-		"network": network,
-		"from":    fromValue,
-		"to":      toValue,
+		fieldKeyModel:   model,
+		fieldKeyNetwork: network,
+		"from":          fromValue,
+		"to":            toValue,
 	}).Debug("querying row count")
 
 	chURL, err := g.buildClickHouseHTTPURL()
@@ -500,9 +506,9 @@ func (g *Generator) QueryTableSample(
 	`, tableRef, network, limit)
 
 	g.log.WithFields(logrus.Fields{
-		"model":   model,
-		"network": network,
-		"limit":   limit,
+		fieldKeyModel:   model,
+		fieldKeyNetwork: network,
+		"limit":         limit,
 	}).Debug("querying table sample")
 
 	chURL, err := g.buildClickHouseHTTPURL()
@@ -652,7 +658,7 @@ func FallbackRangeDiscovery(
 		// For entity models, they typically don't have time-based ranges
 		// Mark them as "none" type - they'll get all data or use correlation
 		if isEntity {
-			gen.log.WithField("model", model).Info("entity/dimension table - will query without range filter")
+			gen.log.WithField(fieldKeyModel, model).Info("entity/dimension table - will query without range filter")
 
 			strategies = append(strategies, TableRangeStrategy{
 				Model:      model,
@@ -686,7 +692,7 @@ func FallbackRangeDiscovery(
 
 		modelRange, queryErr := gen.QueryModelRange(ctx, model, network, rangeCol)
 		if queryErr != nil {
-			gen.log.WithError(queryErr).WithField("model", model).Warn("range query failed")
+			gen.log.WithError(queryErr).WithField(fieldKeyModel, model).Warn("range query failed")
 
 			strategies = append(strategies, TableRangeStrategy{
 				Model:       model,
@@ -705,13 +711,13 @@ func FallbackRangeDiscovery(
 			var minBlock, maxBlock int64
 
 			if _, scanErr := fmt.Sscanf(modelRange.MinRaw, "%d", &minBlock); scanErr != nil {
-				gen.log.WithError(scanErr).WithField("model", model).Warn("failed to parse min block number")
+				gen.log.WithError(scanErr).WithField(fieldKeyModel, model).Warn("failed to parse min block number")
 
 				continue
 			}
 
 			if _, scanErr := fmt.Sscanf(modelRange.MaxRaw, "%d", &maxBlock); scanErr != nil {
-				gen.log.WithError(scanErr).WithField("model", model).Warn("failed to parse max block number")
+				gen.log.WithError(scanErr).WithField(fieldKeyModel, model).Warn("failed to parse max block number")
 
 				continue
 			}

--- a/pkg/seeddata/generator.go
+++ b/pkg/seeddata/generator.go
@@ -114,13 +114,13 @@ func (g *Generator) Generate(ctx context.Context, opts GenerateOptions) (*Genera
 	query := g.buildQuery(opts)
 
 	g.log.WithFields(logrus.Fields{
-		"model":        opts.Model,
-		"network":      opts.Network,
-		"output":       opts.OutputPath,
-		"range_column": opts.RangeColumn,
-		"from":         opts.From,
-		"to":           opts.To,
-		"query":        query,
+		fieldKeyModel:   opts.Model,
+		fieldKeyNetwork: opts.Network,
+		"output":        opts.OutputPath,
+		"range_column":  opts.RangeColumn,
+		"from":          opts.From,
+		"to":            opts.To,
+		"query":         query,
 	}).Info("generating seed data")
 
 	// Execute query and stream to file

--- a/pkg/stack/commands.go
+++ b/pkg/stack/commands.go
@@ -6,17 +6,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Command name constants shared across the stack package. Each stack's
+// ConfigureCommand switch keys on these same values, so they must stay in sync
+// with the corresponding command's Use string.
+const (
+	cmdInit    = "init"
+	cmdCheck   = "check"
+	cmdUp      = "up"
+	cmdDown    = "down"
+	cmdClean   = "clean"
+	cmdBuild   = "build"
+	cmdRebuild = "rebuild"
+	cmdStatus  = "status"
+	cmdLogs    = "logs"
+	cmdStart   = "start"
+	cmdStop    = "stop"
+	cmdRestart = "restart"
+)
+
 // NewInitCommand creates the init subcommand for a stack.
 func NewInitCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init",
+		Use:   cmdInit,
 		Short: fmt.Sprintf("Initialize the %s environment", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.Init(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("init", cmd)
+	s.ConfigureCommand(cmdInit, cmd)
 
 	return cmd
 }
@@ -24,14 +42,14 @@ func NewInitCommand(s Stack) *cobra.Command {
 // NewCheckCommand creates the check subcommand for a stack.
 func NewCheckCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "check",
+		Use:   cmdCheck,
 		Short: fmt.Sprintf("Verify %s environment is ready", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.Check(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("check", cmd)
+	s.ConfigureCommand(cmdCheck, cmd)
 
 	return cmd
 }
@@ -39,14 +57,14 @@ func NewCheckCommand(s Stack) *cobra.Command {
 // NewUpCommand creates the up subcommand for a stack.
 func NewUpCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "up",
+		Use:   cmdUp,
 		Short: fmt.Sprintf("Start the %s stack", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.Up(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("up", cmd)
+	s.ConfigureCommand(cmdUp, cmd)
 
 	return cmd
 }
@@ -54,14 +72,14 @@ func NewUpCommand(s Stack) *cobra.Command {
 // NewDownCommand creates the down subcommand for a stack.
 func NewDownCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "down",
+		Use:   cmdDown,
 		Short: fmt.Sprintf("Stop the %s stack", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.Down(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("down", cmd)
+	s.ConfigureCommand(cmdDown, cmd)
 
 	return cmd
 }
@@ -69,14 +87,14 @@ func NewDownCommand(s Stack) *cobra.Command {
 // NewCleanCommand creates the clean subcommand for a stack.
 func NewCleanCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clean",
+		Use:   cmdClean,
 		Short: fmt.Sprintf("Remove all %s containers and artifacts", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.Clean(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("clean", cmd)
+	s.ConfigureCommand(cmdClean, cmd)
 
 	return cmd
 }
@@ -84,14 +102,14 @@ func NewCleanCommand(s Stack) *cobra.Command {
 // NewBuildCommand creates the build subcommand for a stack.
 func NewBuildCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "build",
+		Use:   cmdBuild,
 		Short: fmt.Sprintf("Build %s projects", s.Name()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return s.Build(cmd.Context(), args)
 		},
 	}
 
-	s.ConfigureCommand("build", cmd)
+	s.ConfigureCommand(cmdBuild, cmd)
 
 	return cmd
 }
@@ -108,7 +126,7 @@ func NewRebuildCommand(s Stack) *cobra.Command {
 		},
 	}
 
-	s.ConfigureCommand("rebuild", cmd)
+	s.ConfigureCommand(cmdRebuild, cmd)
 
 	return cmd
 }
@@ -116,14 +134,14 @@ func NewRebuildCommand(s Stack) *cobra.Command {
 // NewStatusCommand creates the status subcommand for a stack.
 func NewStatusCommand(s Stack) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status",
+		Use:   cmdStatus,
 		Short: fmt.Sprintf("Show %s stack status", s.Name()),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return s.PrintStatus(cmd.Context())
 		},
 	}
 
-	s.ConfigureCommand("status", cmd)
+	s.ConfigureCommand(cmdStatus, cmd)
 
 	return cmd
 }
@@ -147,7 +165,7 @@ func NewLogsCommand(s Stack) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
-	s.ConfigureCommand("logs", cmd)
+	s.ConfigureCommand(cmdLogs, cmd)
 
 	return cmd
 }
@@ -164,7 +182,7 @@ func NewStartCommand(s Stack) *cobra.Command {
 		},
 	}
 
-	s.ConfigureCommand("start", cmd)
+	s.ConfigureCommand(cmdStart, cmd)
 
 	return cmd
 }
@@ -181,7 +199,7 @@ func NewStopCommand(s Stack) *cobra.Command {
 		},
 	}
 
-	s.ConfigureCommand("stop", cmd)
+	s.ConfigureCommand(cmdStop, cmd)
 
 	return cmd
 }
@@ -198,7 +216,7 @@ func NewRestartCommand(s Stack) *cobra.Command {
 		},
 	}
 
-	s.ConfigureCommand("restart", cmd)
+	s.ConfigureCommand(cmdRestart, cmd)
 
 	return cmd
 }

--- a/pkg/stack/lab.go
+++ b/pkg/stack/lab.go
@@ -24,6 +24,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// repoLabFrontend is the repository/project name for the lab frontend. It has
+// no equivalent in the constants package, so it is defined locally.
+const repoLabFrontend = "lab-frontend"
+
 // labStack implements Stack for the lab development environment.
 type labStack struct {
 	log        logrus.FieldLogger
@@ -40,12 +44,12 @@ func NewLabStack(log logrus.FieldLogger, configPath string) Stack {
 	return &labStack{log: log, configPath: configPath}
 }
 
-func (s *labStack) Name() string { return "lab" }
+func (s *labStack) Name() string { return constants.RepoLab }
 
 // ConfigureCommand adds lab-specific flags and descriptions to commands.
 func (s *labStack) ConfigureCommand(name string, cmd *cobra.Command) {
 	switch name {
-	case "init":
+	case cmdInit:
 		cmd.Long = `Initialize the xcli lab environment by discovering repositories,
 checking prerequisites, and ensuring everything is ready to start.
 
@@ -58,7 +62,7 @@ a new machine. It will:
 
 After 'xcli lab init' succeeds, you can start the stack with 'xcli lab up'.`
 
-	case "check":
+	case cmdCheck:
 		cmd.Long = `Perform health checks on the lab environment without starting services.
 
 Verifies:
@@ -82,7 +86,7 @@ Exit codes:
 Example:
   xcli lab check`
 
-	case "up":
+	case cmdUp:
 		cmd.Flags().StringVarP(&s.upMode, "mode", "m", "",
 			"Override mode (local or hybrid)")
 		cmd.Flags().BoolVarP(&s.upVerbose, "verbose", "v", false,
@@ -105,7 +109,7 @@ Examples:
   xcli lab up              # Start all services (always rebuilds)
   xcli lab up --verbose    # Startup with detailed output`
 
-	case "down":
+	case cmdDown:
 		cmd.Long = `Stop all running services and infrastructure in the xcli lab stack.
 
 This will:
@@ -118,7 +122,7 @@ The stack can be restarted with 'xcli lab up'.
 Example:
   xcli lab down`
 
-	case "clean":
+	case cmdClean:
 		cmd.Long = `Completely clean the lab workspace by removing all generated artifacts.
 
 This will:
@@ -147,7 +151,7 @@ Use cases:
 Examples:
   xcli lab clean                   # Remove all containers, volumes, and build artifacts`
 
-	case "build":
+	case cmdBuild:
 		cmd.Long = `Build all lab projects from source without starting services.
 
 Purpose:
@@ -177,7 +181,7 @@ Key difference from 'rebuild':
 Examples:
   xcli lab build         # Build all projects`
 
-	case "rebuild":
+	case cmdRebuild:
 		cmd.Use = "rebuild [project]"
 		cmd.Flags().BoolVarP(&s.rebuildVerbose, "verbose", "v", false,
 			"Enable verbose build output")
@@ -231,7 +235,7 @@ Examples:
 
 Note: All rebuild commands automatically restart their respective services if running.`
 
-	case "status":
+	case cmdStatus:
 		cmd.Long = `Display status of all lab services and infrastructure.
 
 Shows:
@@ -243,10 +247,10 @@ Shows:
 Example:
   xcli lab status`
 
-	case "logs":
+	case cmdLogs:
 		cmd.Long = `Show logs for all lab services or a specific service.`
 
-	case "start":
+	case cmdStart:
 		cmd.Long = `Start a specific lab service.
 
 Available services:
@@ -259,7 +263,7 @@ Example:
   xcli lab start lab-backend
   xcli lab start cbt-mainnet`
 
-	case "stop":
+	case cmdStop:
 		cmd.Long = `Stop a specific lab service.
 
 Available services:
@@ -272,7 +276,7 @@ Example:
   xcli lab stop lab-backend
   xcli lab stop cbt-mainnet`
 
-	case "restart":
+	case cmdRestart:
 		cmd.Long = `Restart a specific lab service.`
 	}
 }
@@ -309,12 +313,12 @@ func (s *labStack) CompleteRebuildTargets() ValidArgsFunc {
 		}
 
 		return []string{
-			"xatu-cbt",
+			constants.RepoXatuCBT,
 			"all",
-			"cbt",
-			"cbt-api",
-			"lab-backend",
-			"lab-frontend",
+			constants.RepoCBT,
+			constants.RepoCBTAPI,
+			constants.RepoLabBackend,
+			repoLabFrontend,
 			"prometheus",
 			"grafana",
 		}, cobra.ShellCompDirectiveNoFileComp
@@ -399,11 +403,11 @@ func (s *labStack) Init(ctx context.Context) error {
 	prereqChecker := prerequisites.NewChecker(s.log)
 
 	repoMap := map[string]string{
-		"cbt":         repos.CBT,
-		"xatu-cbt":    repos.XatuCBT,
-		"cbt-api":     repos.CBTAPI,
-		"lab-backend": repos.LabBackend,
-		"lab":         repos.Lab,
+		constants.RepoCBT:        repos.CBT,
+		constants.RepoXatuCBT:    repos.XatuCBT,
+		constants.RepoCBTAPI:     repos.CBTAPI,
+		constants.RepoLabBackend: repos.LabBackend,
+		constants.RepoLab:        repos.Lab,
 	}
 
 	ui.Header("Checking prerequisites")
@@ -447,11 +451,11 @@ func (s *labStack) Init(ctx context.Context) error {
 	ui.Header("Discovered repositories:")
 
 	rows := [][]string{
-		{"cbt", repos.CBT},
-		{"xatu-cbt", repos.XatuCBT},
-		{"cbt-api", repos.CBTAPI},
-		{"lab-backend", repos.LabBackend},
-		{"lab", repos.Lab},
+		{constants.RepoCBT, repos.CBT},
+		{constants.RepoXatuCBT, repos.XatuCBT},
+		{constants.RepoCBTAPI, repos.CBTAPI},
+		{constants.RepoLabBackend, repos.LabBackend},
+		{constants.RepoLab, repos.Lab},
 	}
 	ui.Table([]string{"Repository", "Path"}, rows)
 
@@ -563,11 +567,11 @@ func (s *labStack) Check(ctx context.Context) error {
 
 		repoCheckPassed := true
 		repos := map[string]string{
-			"cbt":         labCfg.Repos.CBT,
-			"xatu-cbt":    labCfg.Repos.XatuCBT,
-			"cbt-api":     labCfg.Repos.CBTAPI,
-			"lab-backend": labCfg.Repos.LabBackend,
-			"lab":         labCfg.Repos.Lab,
+			constants.RepoCBT:        labCfg.Repos.CBT,
+			constants.RepoXatuCBT:    labCfg.Repos.XatuCBT,
+			constants.RepoCBTAPI:     labCfg.Repos.CBTAPI,
+			constants.RepoLabBackend: labCfg.Repos.LabBackend,
+			constants.RepoLab:        labCfg.Repos.Lab,
 		}
 
 		missingRepos := []string{}
@@ -796,10 +800,10 @@ func (s *labStack) Clean(ctx context.Context) error {
 	spinner = ui.NewSpinner("Removing build artifacts")
 
 	repos := map[string]string{
-		"cbt":         labCfg.Repos.CBT,
-		"xatu-cbt":    labCfg.Repos.XatuCBT,
-		"cbt-api":     labCfg.Repos.CBTAPI,
-		"lab-backend": labCfg.Repos.LabBackend,
+		constants.RepoCBT:        labCfg.Repos.CBT,
+		constants.RepoXatuCBT:    labCfg.Repos.XatuCBT,
+		constants.RepoCBTAPI:     labCfg.Repos.CBTAPI,
+		constants.RepoLabBackend: labCfg.Repos.LabBackend,
 	}
 
 	totalRemoved := 0
@@ -898,10 +902,10 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 	orch.SetVerbose(s.rebuildVerbose)
 
 	switch project {
-	case "xatu-cbt", "all":
+	case constants.RepoXatuCBT, "all":
 		return s.runFullRebuild(ctx, orch, stateDir)
 
-	case "cbt":
+	case constants.RepoCBT:
 		spinner := ui.NewSpinner("Rebuilding CBT")
 
 		if err := orch.Builder().BuildCBT(ctx, true); err != nil {
@@ -924,7 +928,7 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 			}
 		}
 
-	case "cbt-api":
+	case constants.RepoCBTAPI:
 		spinner := ui.NewSpinner("Regenerating protos and rebuilding cbt-api")
 
 		if err := orch.Builder().BuildCBTAPI(ctx, true); err != nil {
@@ -951,7 +955,7 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 		ui.Info("Note: If you added models in xatu-cbt, use " +
 			"'xcli lab rebuild xatu-cbt' for full workflow")
 
-	case "lab-backend":
+	case constants.RepoLabBackend:
 		spinner := ui.NewSpinner("Rebuilding lab-backend")
 
 		if err := orch.Builder().BuildLabBackend(ctx, true); err != nil {
@@ -964,7 +968,7 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 
 		spinner = ui.NewSpinner("Restarting lab-backend")
 
-		if err := orch.Restart(ctx, "lab-backend"); err != nil {
+		if err := orch.Restart(ctx, constants.RepoLabBackend); err != nil {
 			spinner.Fail("Could not restart lab-backend")
 			ui.Info("If lab-backend is running, restart it manually:")
 			ui.Info("  xcli lab restart lab-backend")
@@ -972,7 +976,7 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 			spinner.Success("lab-backend restarted successfully")
 		}
 
-	case "lab-frontend":
+	case repoLabFrontend:
 		spinner := ui.NewSpinner("Regenerating lab-frontend API types from cbt-api")
 
 		if err := orch.Builder().BuildLabFrontend(ctx); err != nil {
@@ -985,7 +989,7 @@ func (s *labStack) Rebuild(ctx context.Context, project string) error {
 
 		spinner = ui.NewSpinner("Restarting lab-frontend")
 
-		if err := orch.Restart(ctx, "lab-frontend"); err != nil {
+		if err := orch.Restart(ctx, repoLabFrontend); err != nil {
 			spinner.Fail("Could not restart lab-frontend")
 			ui.Info("If lab-frontend is running, restart it manually:")
 			ui.Info("  xcli lab restart lab-frontend")
@@ -1215,7 +1219,7 @@ func (s *labStack) runFullRebuild(
 		now := time.Now()
 		report.AddResult(diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "xatu-cbt",
+			Service:   constants.RepoXatuCBT,
 			Success:   false,
 			ErrorMsg:  "skipped due to proto generation failure",
 			StartTime: now,
@@ -1243,7 +1247,7 @@ func (s *labStack) runFullRebuild(
 		now := time.Now()
 		report.AddResult(diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseBuild,
-			Service:   "cbt-api",
+			Service:   constants.RepoCBTAPI,
 			Success:   false,
 			ErrorMsg:  "skipped due to xatu-cbt build failure",
 			StartTime: now,
@@ -1398,7 +1402,7 @@ func (s *labStack) runFullRebuild(
 
 		report.AddResult(diagnostic.BuildResult{
 			Phase:     diagnostic.PhaseFrontendGen,
-			Service:   "lab-frontend",
+			Service:   repoLabFrontend,
 			Success:   false,
 			ErrorMsg:  skipReason,
 			StartTime: now,
@@ -1418,7 +1422,7 @@ func (s *labStack) runFullRebuild(
 			waitEnd := time.Now()
 			report.AddResult(diagnostic.BuildResult{
 				Phase:   diagnostic.PhaseFrontendGen,
-				Service: "lab-frontend",
+				Service: repoLabFrontend,
 				Success: false,
 				Error:   waitErr,
 				ErrorMsg: fmt.Sprintf(
@@ -1438,7 +1442,7 @@ func (s *labStack) runFullRebuild(
 			} else {
 				spinner.UpdateText("[7/7] Restarting lab-frontend")
 
-				if err := orch.Restart(ctx, "lab-frontend"); err != nil {
+				if err := orch.Restart(ctx, repoLabFrontend); err != nil {
 					spinner.Fail("Could not restart lab-frontend")
 					ui.Warning(fmt.Sprintf(
 						"Could not restart lab-frontend: %v", err))

--- a/pkg/stack/lab.go
+++ b/pkg/stack/lab.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethpandaops/xcli/pkg/builder"
 	"github.com/ethpandaops/xcli/pkg/config"
+	"github.com/ethpandaops/xcli/pkg/constants"
 	"github.com/ethpandaops/xcli/pkg/diagnostic"
 	"github.com/ethpandaops/xcli/pkg/discovery"
 	"github.com/ethpandaops/xcli/pkg/orchestrator"
@@ -352,6 +353,8 @@ func (s *labStack) Init(ctx context.Context) error {
 		resolvedConfigPath = absPath
 	}
 
+	var existingXatu *config.ClickHouseClusterConfig
+
 	if rootCfg.Lab != nil {
 		s.log.Warn("lab configuration already exists")
 		fmt.Print("Overwrite existing lab configuration? (y/N): ")
@@ -365,6 +368,11 @@ func (s *labStack) Init(ctx context.Context) error {
 
 			return nil
 		}
+
+		// Preserve existing external ClickHouse credentials so the overwrite can
+		// offer them as defaults rather than silently discarding them.
+		xatu := rootCfg.Lab.Infrastructure.ClickHouse.Xatu
+		existingXatu = &xatu
 	}
 
 	cwd, err := os.Getwd()
@@ -415,6 +423,10 @@ func (s *labStack) Init(ctx context.Context) error {
 	labCfg := config.DefaultLab()
 	labCfg.Repos = *repos
 
+	if err := promptXatuClickHouseCredentials(labCfg, existingXatu); err != nil {
+		return err
+	}
+
 	rootCfg.Lab = labCfg
 
 	if err := rootCfg.Save(resolvedConfigPath); err != nil {
@@ -449,6 +461,72 @@ func (s *labStack) Init(ctx context.Context) error {
 	ui.Header("Next steps:")
 	fmt.Println("  1. Review and edit the 'lab:' section in .xcli.yaml if needed")
 	fmt.Println("  2. Run 'xcli lab up' to start the lab stack")
+
+	return nil
+}
+
+// promptXatuClickHouseCredentials optionally collects username/password for the
+// external Xatu ClickHouse cluster. Both prompts may be left blank to skip,
+// which leaves credentials unset (e.g. for unauthenticated or in-URL access).
+// When prior is non-nil (overwriting an existing config), its credentials are
+// offered as defaults so an overwrite preserves them unless explicitly changed.
+func promptXatuClickHouseCredentials(labCfg *config.LabConfig, prior *config.ClickHouseClusterConfig) error {
+	xatu := &labCfg.Infrastructure.ClickHouse.Xatu
+	if xatu.Mode != constants.InfraModeExternal {
+		return nil
+	}
+
+	var priorUser, priorPass string
+	if prior != nil {
+		priorUser = prior.ExternalUsername
+		priorPass = prior.ExternalPassword
+	}
+
+	ui.Header("External Xatu ClickHouse credentials (optional)")
+	ui.Info(fmt.Sprintf("Connecting to: %s", xatu.ExternalURL))
+
+	if priorUser != "" {
+		fmt.Printf("Username [%s] (enter to keep, '-' to clear): ", priorUser)
+	} else {
+		ui.Info("Leave blank to skip (use an unauthenticated cluster or credentials in the URL).")
+		fmt.Print("Username: ")
+	}
+
+	var username string
+
+	_, _ = fmt.Scanln(&username)
+
+	username = strings.TrimSpace(username)
+
+	switch username {
+	case "":
+		// Empty keeps the existing username (or stays empty to skip entirely).
+		username = priorUser
+	case "-":
+		// Sentinel to remove previously-stored credentials.
+		xatu.ExternalUsername = ""
+		xatu.ExternalPassword = ""
+
+		return nil
+	}
+
+	if username == "" {
+		return nil
+	}
+
+	// Reuse the existing password when the username is unchanged and the user
+	// leaves the password blank; otherwise take the freshly entered value.
+	password, err := ui.PasswordInput("Password: ")
+	if err != nil {
+		return fmt.Errorf("failed to read ClickHouse password: %w", err)
+	}
+
+	if password == "" && username == priorUser {
+		password = priorPass
+	}
+
+	xatu.ExternalUsername = username
+	xatu.ExternalPassword = password
 
 	return nil
 }

--- a/pkg/tui/colors.go
+++ b/pkg/tui/colors.go
@@ -8,6 +8,7 @@ const (
 
 	healthHealthy   = "healthy"
 	healthUnhealthy = "unhealthy"
+	healthUnknown   = "unknown"
 
 	panelServices = "services"
 	panelActions  = "actions"

--- a/pkg/tui/health.go
+++ b/pkg/tui/health.go
@@ -79,7 +79,7 @@ func (hm *HealthMonitor) checkAll() {
 	for _, svc := range services {
 		if svc.Status != statusRunning {
 			hm.services[svc.Name] = HealthStatus{
-				Status:    "unknown",
+				Status:    healthUnknown,
 				LastCheck: time.Now(),
 			}
 
@@ -103,7 +103,7 @@ func (hm *HealthMonitor) checkAll() {
 func (hm *HealthMonitor) checkService(svc ServiceInfo) HealthStatus {
 	status := HealthStatus{
 		LastCheck: time.Now(),
-		Status:    "unknown",
+		Status:    healthUnknown,
 	}
 
 	// Determine check method based on service type

--- a/pkg/tui/logs.go
+++ b/pkg/tui/logs.go
@@ -246,8 +246,8 @@ func ParseLine(service, raw string) LogLine {
 
 	// Extract level from anywhere in line as fallback
 	upperStripped := strings.ToUpper(stripped)
-	if strings.Contains(upperStripped, "ERROR") || strings.Contains(upperStripped, "ERRO") {
-		line.Level = "ERROR"
+	if strings.Contains(upperStripped, LogLevelError) || strings.Contains(upperStripped, "ERRO") {
+		line.Level = LogLevelError
 	} else if strings.Contains(upperStripped, "WARN") {
 		line.Level = "WARN"
 	} else if strings.Contains(upperStripped, "DEBUG") {
@@ -296,7 +296,7 @@ func (ls *LogStreamer) streamPipe(ctx context.Context, serviceName string, pipe 
 		errLine := LogLine{
 			Service:   serviceName,
 			Timestamp: time.Now(),
-			Level:     "ERROR",
+			Level:     LogLevelError,
 			Message:   "Log scanner error: " + err.Error(),
 			Raw:       err.Error(),
 		}

--- a/pkg/tui/orchestrator.go
+++ b/pkg/tui/orchestrator.go
@@ -74,7 +74,7 @@ func (w *OrchestratorWrapper) GetServices() []ServiceInfo {
 				Status: statusStopped,
 				URL:    w.orch.GetServiceURL(name),
 				Ports:  w.orch.GetServicePorts(name),
-				Health: "unknown",
+				Health: healthUnknown,
 			}
 
 			if status, ok := obsStatus[name]; ok {
@@ -94,7 +94,7 @@ func (w *OrchestratorWrapper) GetServices() []ServiceInfo {
 			Status: statusStopped,
 			URL:    w.orch.GetServiceURL(name),
 			Ports:  w.orch.GetServicePorts(name),
-			Health: "unknown",
+			Health: healthUnknown,
 		}
 
 		// Find running process
@@ -144,7 +144,7 @@ func (w *OrchestratorWrapper) GetInfrastructure() []InfraInfo {
 			status = "running"
 		}
 
-		infraType := "unknown"
+		infraType := healthUnknown
 		if contains(name, "ClickHouse") {
 			infraType = "clickhouse"
 		} else if contains(name, "Redis") {

--- a/pkg/tui/view.go
+++ b/pkg/tui/view.go
@@ -389,7 +389,7 @@ func (m Model) formatLogLineWithHighlight(line LogLine) string {
 	var levelIndicator string
 
 	switch line.Level {
-	case "ERROR", "ERRO":
+	case LogLevelError, "ERRO":
 		levelIndicator = StyleError.Render("E")
 	case "WARN", "WARNING":
 		levelIndicator = lipgloss.NewStyle().Foreground(ColorYellow).Render("W")

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -2,8 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/pterm/pterm"
+	"golang.org/x/term"
 )
 
 // TextInput displays an interactive text input and returns the entered value.
@@ -22,6 +25,33 @@ func TextInput(prompt string, defaultValue string) (string, error) {
 	}
 
 	return result, nil
+}
+
+// PasswordInput prints prompt and reads a line from stdin without echoing it,
+// so the typed value stays hidden. The returned value may be empty. When stdin
+// is not an interactive terminal, it falls back to a normal (echoed) read so
+// piped/non-tty input still works.
+func PasswordInput(prompt string) (string, error) {
+	fmt.Print(prompt)
+
+	fd := int(os.Stdin.Fd())
+	if term.IsTerminal(fd) {
+		b, err := term.ReadPassword(fd)
+
+		fmt.Println()
+
+		if err != nil {
+			return "", fmt.Errorf("failed to read password: %w", err)
+		}
+
+		return strings.TrimSpace(string(b)), nil
+	}
+
+	var result string
+
+	_, _ = fmt.Scanln(&result)
+
+	return strings.TrimSpace(result), nil
 }
 
 // TextInputRequired displays an interactive text input that requires a non-empty value.


### PR DESCRIPTION
## Summary

Adds optional username/password collection during `xcli lab init` and — more importantly — ensures those credentials actually reach the external Xatu ClickHouse cluster. Previously, credentials stored in the `externalUsername`/`externalPassword` config fields were never propagated to `xatu-cbt`, so the CBT worker connected as user `default` with no password and failed with `Code: 516 ... AUTHENTICATION_FAILED`.

Also renames the default Xatu cluster host from `chendpoint-xatu-clickhouse` to `chendpoint-clickhouse-raw` (default config, infra host-prefix constant, and shard-DNS doc comment).

## The bug

`xatu-cbt infra start` reads ClickHouse credentials **only** from the `--xatu-url` flag's userinfo (`internal/infra/clickhouse_config.go`). xcli was passing the bare URL, so the generated `xatu_cluster` remote-server config had no credentials → the worker's `cluster('xatu_cluster', ...)` queries authenticated as `default` and were rejected.

## Changes

- **`lab init` prompt** — when the Xatu cluster is in `external` mode, prompt for an optional username/password. Blank input skips (unauthenticated cluster or credentials embedded in the URL). On overwrite the existing username is shown as the default; blank keeps current credentials, and a `-` sentinel clears them.
- **`ui.PasswordInput`** — masked input via `golang.org/x/term`, with an echoed fallback for non-tty stdin. Replaces the pterm interactive widget, whose live-area repaint collided with spinners and visibly garbled the prompt.
- **`config.ClickHouseClusterConfig.ExternalURLWithCredentials()`** — embeds the separately-configured `externalUsername`/`externalPassword` into the URL userinfo (URL-embedded credentials preserved unless overridden; password-only falls back to the `default` user; values percent-encoded).
- **infrastructure** — pass the credentialed URL to `xatu-cbt infra start --xatu-url` (the actual fix).
- **builder** — apply the same embedding to the `XATU_URL` env var used for proto generation.
- **tests** — table test for `ExternalURLWithCredentials` (no-creds, embed, explicit-overrides-URL, URL-preserved, password-only fallback, special-char encoding, https, error path).

## Known trade-off (documented in code)

Embedding credentials in `--xatu-url` exposes the password via the child process command line (`/proc/<pid>/cmdline`, world-readable on Linux) for the duration of the short-lived `infra start` call. `xatu-cbt`'s infra-start has no env/file alternative to the flag today; switching to an env var (as the builder path uses) would require a change there. The password is already persisted to disk by `xatu-cbt`'s generated config, so this introduces no new on-disk exposure. Tracked as a follow-up.

## Testing

- `go build ./...` — clean
- `go vet ./pkg/config/... ./pkg/stack/... ./pkg/infrastructure/... ./pkg/builder/...` — clean
- `go test ./pkg/config/...` — 9/9 cases pass

## Migration notes

No config changes required for users who already have `externalUsername`/`externalPassword` set — rebuild and cycle the stack (`xcli lab down && xcli lab up`) so `xatu-cbt infra start` regenerates the `xatu_cluster` config with credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)