### PR TITLE
fix(bounds-seeder): target clickhouse namespace + cbt-redis after raw migration

### DIFF
--- a/pkg/infrastructure/bounds_seeder.go
+++ b/pkg/infrastructure/bounds_seeder.go
@@ -13,8 +13,10 @@ import (
 
 const (
 	// Production cluster hardcoded details.
+	// The cbt deployment (and its Redis) lives in the clickhouse namespace since the
+	// clickhouse-raw migration; it was previously xatu-cbt in the xatu namespace.
 	prodK8sContext = "platform-analytics-hel1-production"
-	prodNamespace  = "xatu"
+	prodNamespace  = "clickhouse"
 
 	// localRedisContainer is the local Docker container name for xatu-cbt Redis.
 	localRedisContainer = "xatu-cbt-redis"
@@ -258,8 +260,8 @@ func (s *BoundsSeeder) bulkInsertLocal(ctx context.Context, redisDB int, bounds 
 
 // prodRedisDetails returns the production Redis pod name and password k8s secret name for a network.
 func prodRedisDetails(network string) (podName, secretName string) {
-	return fmt.Sprintf("%s-xatu-cbt-redis-node-0", network),
-		fmt.Sprintf("%s-xatu-cbt-redis", network)
+	return fmt.Sprintf("%s-cbt-redis-node-0", network),
+		fmt.Sprintf("%s-cbt-redis", network)
 }
 
 // stripRedisPrefix removes the "N) " prefix that redis-cli adds to array elements.


### PR DESCRIPTION
The external-bounds seeder pulled production bounds from `<network>-xatu-cbt-redis-node-0` (secret `<network>-xatu-cbt-redis`) in the `xatu` namespace, but since the clickhouse-raw migration prod cbt and its Redis moved to the `clickhouse` namespace and dropped the `xatu-` prefix (`<network>-cbt-redis-node-0`, secret `<network>-cbt-redis`); the stale coordinates made `SeedFromProduction` fail silently (it's non-fatal), leaving local Redis empty so CBT fell back to multi-billion-row min/max scans of external tables on cold start. This points the seeder at the current location. Verified locally: `lab up` now seeds 58 `cbt:external:*` bound keys from `mainnet-cbt-redis-node-0` (e.g. `canonical_execution_logs` min 52029 / max 25371147), so CBT reads bounds from Redis instead of scanning.