### PR TITLE
feat(lab): devnet-ready config generation and test seeding

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,16 @@ type LabConfig struct {
 	Ports          LabPortsConfig       `yaml:"ports"`
 	Dev            LabDevConfig         `yaml:"dev"`
 	TUI            TUIConfig            `yaml:"tui"`
+	CBT            LabCBTConfig         `yaml:"cbt,omitempty"`
+}
+
+// LabCBTConfig contains CBT engine defaults applied to generated configs.
+type LabCBTConfig struct {
+	// DefaultBackfillDuration bounds how far back external models scan
+	// (EXTERNAL_MODEL_MIN_TIMESTAMP = now - duration). Defaults to 1h.
+	// Canonical (cannon-derived) tables lag hours behind head, so short
+	// windows can leave canonical-sourced models with no data in range.
+	DefaultBackfillDuration string `yaml:"defaultBackfillDuration,omitempty"`
 }
 
 // LabInstanceConfig contains per-instance identity settings.

--- a/pkg/configgen/generator.go
+++ b/pkg/configgen/generator.go
@@ -154,9 +154,19 @@ func (g *Generator) GenerateCBTConfig(network string, userOverridesPath string) 
 
 	networkPorts := g.networkPorts(network)
 
+	// Well-known networks resolve from constants; custom networks (devnets)
+	// declare genesisTimestamp on their entry in .xcli.yaml.
 	var genesisTimestamp uint64
 	if timestamp, ok := constants.NetworkGenesisTimestamps[network]; ok {
 		genesisTimestamp = timestamp
+	}
+
+	for _, net := range g.cfg.Networks {
+		if net.Name == network && net.GenesisTimestamp != 0 {
+			genesisTimestamp = net.GenesisTimestamp
+
+			break
+		}
 	}
 
 	data := map[string]any{
@@ -329,7 +339,18 @@ func (g *Generator) GenerateLabBackendConfig(
 
 // generateAutoDefaults creates xcli-generated defaults for models (env, overrides).
 func (g *Generator) generateAutoDefaults(network string) (map[string]any, error) {
-	externalModelMinTimestamp := time.Now().Add(-1 * time.Hour).Unix()
+	backfill := time.Hour
+
+	if g.cfg.CBT.DefaultBackfillDuration != "" {
+		parsed, err := time.ParseDuration(g.cfg.CBT.DefaultBackfillDuration)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cbt.defaultBackfillDuration %q: %w", g.cfg.CBT.DefaultBackfillDuration, err)
+		}
+
+		backfill = parsed
+	}
+
+	externalModelMinTimestamp := time.Now().Add(-backfill).Unix()
 
 	// Set sane default for mainnet
 	externalModelMinBlock := 0

--- a/pkg/seeddata/generator.go
+++ b/pkg/seeddata/generator.go
@@ -528,7 +528,19 @@ func (g *Generator) buildClickHouseHTTPURL() (string, error) {
 // If the model's frontmatter specifies a database and table, it uses those.
 // Otherwise it falls back to "default.modelName" for backward compatibility.
 func (g *Generator) resolveTableRef(model string) string {
-	return ResolveExternalTableRef(model, g.cfg.Repos.XatuCBT)
+	ref := ResolveExternalTableRef(model, g.cfg.Repos.XatuCBT)
+
+	// Frontmatter-declared databases win. Otherwise prefer the instance's
+	// configured external database — per-devnet raw tables live in databases
+	// named after the network, not in "default".
+	if strings.HasPrefix(ref, "default.") {
+		if db := g.cfg.Infrastructure.ClickHouse.Xatu.ExternalDatabase; db != "" && db != "default" {
+			// Devnet database names contain dashes, so quote the identifier.
+			return "`" + db + "`." + strings.TrimPrefix(ref, "default.")
+		}
+	}
+
+	return ref
 }
 
 // formatSQLValue formats a value for use in SQL.


### PR DESCRIPTION
Four fixes surfaced by running the lab stack against glamsterdam devnets:

- Generated CBT configs use a network's `genesisTimestamp` from `.xcli.yaml` when the network isn't in the well-known constants map, so devnets get a correct slot interval expression instead of genesis 0.
- `cbt.defaultBackfillDuration` (previously accepted but silently ignored) now drives `EXTERNAL_MODEL_MIN_TIMESTAMP` instead of a hardcoded now-1h. Canonical tables lag hours behind head, so the 1h window left canonical-sourced models with zero rows in range.
- The seed-data generator qualified unresolved externals as `default.<table>`, which overrides the connection's database param and breaks per-devnet raw databases. It now honors the configured external database, backtick-quoted since devnet names contain dashes.
- Frontmatter-declared databases still take precedence in both cases.